### PR TITLE
[addax-storage] Fix read gzip compress file Incompletely #309 #310

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -133,7 +133,7 @@ public class StorageReaderUtil
                     reader = new BufferedReader(new InputStreamReader(lzopInputStream, encoding));
                 }
                 else if ("gzip".equalsIgnoreCase(compress)) {
-                    CompressorInputStream compressorInputStream = new GzipCompressorInputStream(inputStream);
+                    CompressorInputStream compressorInputStream = new GzipCompressorInputStream(inputStream, true);
                     reader = new BufferedReader(new InputStreamReader(compressorInputStream, encoding), bufferSize);
                 }
                 else if ("bzip2".equalsIgnoreCase(compress)) {


### PR DESCRIPTION
1. create two plain texts assume 1.txt and 2.txt, each file contains from 1 to 10
2. use `gzip -c 1.txt 2.txt >test.gz`
3. reader test.gz, only get 10 lines instead of 20 lines
4. use `cat 1.txt 2.txt |gzip >test.gz` is correct