### PR TITLE
[txtfilereader] Fix read gzip compress file Incompletely

### DIFF
--- a/plugin/reader/txtfilereader/src/main/java/com/wgzhao/addax/plugin/reader/txtfilereader/FileHelper.java
+++ b/plugin/reader/txtfilereader/src/main/java/com/wgzhao/addax/plugin/reader/txtfilereader/FileHelper.java
@@ -107,7 +107,7 @@ public class FileHelper
                 }
                 else {
                     BufferedInputStream bis = new BufferedInputStream(inputStream);
-                    CompressorInputStream input = new CompressorStreamFactory().createCompressorInputStream(bis);
+                    CompressorInputStream input = new CompressorStreamFactory().createCompressorInputStream(compressType, bis, true);
                     reader = new BufferedReader(new InputStreamReader(input, encoding), bufferSize);
                 }
             }


### PR DESCRIPTION
Fix #309 
1. create two plain texts assume 1.txt and 2.txt, each file contains from 1 to 10
2. use `gzip -c 1.txt 2.txt >test.gz`
3. reader test.gz, only get 10 lines instead of 20 lines
4. use `cat 1.txt 2.txt |gzip >test.gz` is correct