### PR TITLE
downgrade fastjson to 1.2.76 to fix  violates error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <commons.configuration.version>1.10</commons.configuration.version>
         <commons.cli.version>1.5.0</commons.cli.version>
         <druid.version>1.2.6</druid.version>
-        <fastjson.version>1.2.78</fastjson.version>
+        <fastjson.version>1.2.76</fastjson.version>
         <guava.version>29.0-jre</guava.version>
         <groovy.version>2.4.21</groovy.version>
         <diamond.version>3.7.3</diamond.version>


### PR DESCRIPTION
In `fastjson 1.2.76` version,  it has a high probability of `Comparison errors Comparison method violates its general contract` occurred
referernces https://github.com/alibaba/fastjson/issues/3909