### PR TITLE
hdfswriter添加hadoop-hdfs.jar

### DIFF
--- a/plugin/writer/hdfswriter/pom.xml
+++ b/plugin/writer/hdfswriter/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
- hdfswriter添加hadoop-hdfs.jar，修复在HA+k8s配置下写入报 `No FileSystem for scheme "hdfs"`