### PR TITLE
Add support for load groovy code from special file path.

### DIFF
--- a/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
@@ -28,6 +28,7 @@ import com.wgzhao.addax.core.transport.transformer.TransformerInfo;
 import com.wgzhao.addax.core.transport.transformer.TransformerRegistry;
 import com.wgzhao.addax.core.util.container.CoreConstant;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,7 +126,8 @@ public class TransformerUtil
                 if (StringUtils.isNotEmpty(codeFile)) {
                     // load groovy code from codeFile
                     // the codeFile default relative path is the same of addax.home properties
-                    File file = new File(codeFile);
+                    // Fix Potential Path Traversal
+                    File file = new File(FilenameUtils.getFullPath(codeFile) + FilenameUtils.getName(codeFile));
                     if (! file.exists() || ! file.isFile()) {
                         throw AddaxException.asAddaxException(TransformerErrorCode.TRANSFORMER_CONFIGURATION_ERROR,
                                 "the codeFile [" + codeFile + "]does not exists or is unreadable!");

--- a/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
@@ -126,8 +126,7 @@ public class TransformerUtil
                 if (StringUtils.isNotEmpty(codeFile)) {
                     // load groovy code from codeFile
                     // the codeFile default relative path is the same of addax.home properties
-                    // Fix Potential Path Traversal
-                    File file = new File(FilenameUtils.getFullPath(codeFile) + FilenameUtils.getName(codeFile));
+                    File file = new File(codeFile);
                     if (! file.exists() || ! file.isFile()) {
                         throw AddaxException.asAddaxException(TransformerErrorCode.TRANSFORMER_CONFIGURATION_ERROR,
                                 "the codeFile [" + codeFile + "]does not exists or is unreadable!");

--- a/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
@@ -27,10 +27,16 @@ import com.wgzhao.addax.core.transport.transformer.TransformerExecutionParas;
 import com.wgzhao.addax.core.transport.transformer.TransformerInfo;
 import com.wgzhao.addax.core.transport.transformer.TransformerRegistry;
 import com.wgzhao.addax.core.util.container.CoreConstant;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,9 +113,29 @@ public class TransformerUtil
             }
             else {
                 String code = configuration.getString(CoreConstant.TRANSFORMER_PARAMETER_CODE);
-                if (StringUtils.isEmpty(code)) {
+                String codeFile = configuration.getString(CoreConstant.TRANSFORMER_PARAMETER_CODE_FILE);
+                if (StringUtils.isAllEmpty(code, codeFile)) {
                     throw AddaxException.asAddaxException(TransformerErrorCode.TRANSFORMER_ILLEGAL_PARAMETER,
-                            "groovy code must be set by UDF: name=" + functionName);
+                            "groovy code or codeFile must be set by UDF: name=" + functionName);
+                }
+                // code and codeFile both setup, prefers to code , ignore codeFile
+                if ( StringUtils.isNoneEmpty(code, codeFile)) {
+                    LOG.warn("Both setup code and codeFile, will pickup code, ignore the codeFile");
+                }
+                if (StringUtils.isNotEmpty(codeFile)) {
+                    // load groovy code from codeFile
+                    // the codeFile default relative path is the same of addax.home properties
+                    File file = new File(codeFile);
+                    if (! file.exists() || ! file.isFile()) {
+                        throw AddaxException.asAddaxException(TransformerErrorCode.TRANSFORMER_CONFIGURATION_ERROR,
+                                "the codeFile [" + codeFile + "]does not exists or is unreadable!");
+                    }
+                    try {
+                        code = FileUtils.readFileToString(file, Charset.defaultCharset());
+                    } catch (IOException e) {
+                        throw AddaxException.asAddaxException(TransformerErrorCode.TRANSFORMER_RUN_EXCEPTION,
+                                "read codeFile [" + codeFile + "] failure:", e);
+                    }
                 }
                 transformerExecutionParas.setCode(code);
 

--- a/core/src/main/java/com/wgzhao/addax/core/util/container/CoreConstant.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/container/CoreConstant.java
@@ -136,6 +136,9 @@ public class CoreConstant
     public static final String TRANSFORMER_PARAMETER_CODE = "parameter.code";
     public static final String TRANSFORMER_PARAMETER_EXTRA_PACKAGE = "parameter.extraPackage";
 
+    // load groovy code from special file
+    public static final String TRANSFORMER_PARAMETER_CODE_FILE = "parameter.codeFile";
+
     public static final String TASK_ID = "taskId";
 
     // ----------------------------- 环境变量 ---------------------------------

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -162,6 +162,36 @@ String code3="Column column = record.getColumn(1);\n"+
         " return record;";
 ```
 
+从  `4.1.2` 版本开始， `dx_groovy` 支持从外部文件加载 groovy 代码，读取文件的相对路径为 `$ADDAX_HOME` 变量所在的目录，也就是 Addax 的安装目录。
+
+以实现 `subStr` 为例，我们可以创建 `job/substr.groovy` 文件，内容如下：
+
+```groovy
+Column column = record.getColumn(1)
+String oriValue = column.asString()
+String newValue = oriValue.substring(0, 3)
+record.setColumn(1, new StringColumn(newValue))
+return record
+```
+
+然后在 `job` 文件中这样去定义：
+
+```json
+{
+  "transformer": [
+    {
+      "name": "dx_groovy",
+      "parameter": {
+        "codeFile": "job/substr.groovy"
+      }
+    }
+  ]
+}
+```
+
+文件也可以使用绝对路径来指定。
+
+
 ## Job定义
 
 本例中，配置4个UDF。


### PR DESCRIPTION

Support the loading of Groovy code from a specified file. If your Groovy code is extensive, writing it directly into the job file will appear cumbersome, and there will also be issues regarding symbol escaping. By utilizing the approach of loading from an external file, the job file can remain concise.