### PR TITLE
Fix postgresql's update write mode got error when update columns contains 'update' characters

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/WriterUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/WriterUtil.java
@@ -177,7 +177,7 @@ public final class WriterUtil
 
     private static String doPostgresqlUpdate(String writeMode, List<String> columnHolders)
     {
-        String conflict = writeMode.replace("update", "");
+        String conflict = writeMode.replaceFirst("update", "");
         StringBuilder sb = new StringBuilder();
         sb.append(" ON CONFLICT ");
         sb.append(conflict);


### PR DESCRIPTION
example: 
```
{
    "writeMode": "update(id, updated_at)"
}
```
update columns will be processed as `id,updated_at` instead of `id,d_at`.