### PR TITLE
Upgrade Project Compilation to JDK 17

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/setup-java@v4.7.1
       with:
         # The Java version to make available on the path. Takes a whole or semver Java version, or 1.x syntax (e.g. 1.8 => Java 8.x). Early access versions can be specified in the form of e.g. 14-ea, 14.0.0-ea, or 14.0.0-ea.28
-        java-version: 1.8
+        java-version: 17
         # The package type (jre, jdk, jdk+fx)
         java-package: jdk # optional, default is jdk
         # The architecture (x86, x64) of the package.

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,10 +22,10 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.8
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - run: |
           export MAVEN_OPTS="-DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dgpg.skip=true"

--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-        <jdk.version>1.8</jdk.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <jdk.version>17</jdk.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <modules>
@@ -1334,6 +1335,9 @@
                         <version>2.15.0</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request updates the project's compilation environment to use JDK 17 while ensuring that the compiled package remains compatible with JDK 8 through JDK 17. This approach allows the project to leverage the new features and performance improvements of JDK 17 during the build process while maintaining compatibility with a broader range of JDK versions, ensuring support for older environments.