### PR TITLE
[feature][add][server] add minimal HTTP server module for job submission and status query

### DIFF
--- a/build-module.sh
+++ b/build-module.sh
@@ -113,6 +113,13 @@ build_module() {
         return 0
     fi
 
+    if [ "$MODULE_NAME" == "server" ]; then
+        echo "Deploying server module..."
+        rsync -av server/target/${MODULE_NAME}-${version}.jar ${ADDAX_HOME}/lib/
+        echo "Server module deployed successfully"
+        return 0
+    fi
+
     if [ "$MODULE_NAME" == "addax-rdbms" ] || [ "$MODULE_NAME" == "addax-storage" ]; then
         echo "Deploying $MODULE_NAME module..."
         rsync -av lib/${MODULE_NAME}/target/${MODULE_NAME}-${version}.jar ${ADDAX_HOME}/lib/

--- a/core/src/main/bin/addax-server.sh
+++ b/core/src/main/bin/addax-server.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# addax-server.sh - start/stop the minimal Addax server (JDK HttpServer based)
+# Usage:
+#   addax-server.sh start [-p <parallel>] [--port <port>] [--daemon]
+#   addax-server.sh stop
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/../../.."
+PID_FILE="$SCRIPT_DIR/addax-server.pid"
+OUT_FILE="$SCRIPT_DIR/addax-server.out"
+
+find_jar() {
+  # pattern is a glob relative to project root, use find to locate it
+  pattern="$1"
+  find "$PROJECT_ROOT" -name "$pattern" -type f -print | head -n 1
+}
+
+start_server() {
+  PARALLEL=30
+  PORT=8080
+  DAEMON=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -p|--parallel)
+        PARALLEL="$2"; shift 2;;
+      --port)
+        PORT="$2"; shift 2;;
+      --daemon)
+        DAEMON=1; shift;;
+      *)
+        shift;;
+    esac
+  done
+
+  # Try expected build output locations first
+  SERVER_JAR="$PROJECT_ROOT/server/target/server-*.jar"
+  CORE_JAR="$PROJECT_ROOT/core/target/addax-core-*.jar"
+
+  # Resolve actual files (globs)
+  SERVER_JAR_RESOLVED=$(ls $SERVER_JAR 2>/dev/null || true)
+  CORE_JAR_RESOLVED=$(ls $CORE_JAR 2>/dev/null || true)
+
+  # Fallback to find if not found
+  if [[ -z "$SERVER_JAR_RESOLVED" ]]; then
+    SERVER_JAR_RESOLVED=$(find_jar "server-*.jar")
+  fi
+  if [[ -z "$CORE_JAR_RESOLVED" ]]; then
+    CORE_JAR_RESOLVED=$(find_jar "addax-core-*.jar")
+  fi
+
+  if [[ -z "$SERVER_JAR_RESOLVED" || -z "$CORE_JAR_RESOLVED" ]]; then
+    echo "Error: cannot find server or core jars. Build the project first: mvn -DskipTests clean package -pl :server,:core -am"
+    exit 1
+  fi
+
+  CMD=(java -cp "$SERVER_JAR_RESOLVED:$CORE_JAR_RESOLVED" com.wgzhao.addax.server.ServerApplication --port "$PORT" -p "$PARALLEL")
+
+  if [[ $DAEMON -eq 1 ]]; then
+    nohup "${CMD[@]}" > "$OUT_FILE" 2>&1 &
+    echo $! > "$PID_FILE"
+    echo "Addax server started in background (PID: $(cat $PID_FILE)). Logs: $OUT_FILE"
+  else
+    "${CMD[@]}"
+  fi
+}
+
+stop_server() {
+  if [[ -f "$PID_FILE" ]]; then
+    PID=$(cat "$PID_FILE")
+    if kill "$PID" >/dev/null 2>&1; then
+      echo "Stopped process $PID"
+      rm -f "$PID_FILE"
+    else
+      echo "Failed to stop process $PID (it may no longer be running)";
+      rm -f "$PID_FILE" || true
+    fi
+  else
+    echo "PID file not found: $PID_FILE. Server may not be running."
+  fi
+}
+
+case "${1:-}" in
+  start)
+    shift || true
+    start_server "$@"
+    ;;
+  stop)
+    stop_server
+    ;;
+  *)
+    echo "Usage: $0 {start [-p <parallel>] [--port <port>] [--daemon] | stop}"
+    exit 1
+    ;;
+esac

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1,0 +1,85 @@
+# Server Module
+
+The Server module provides HTTP interfaces for submitting and managing data collection tasks. Users can submit JSON job configurations via POST, and the server executes tasks asynchronously, returning a unique task ID. Progress and results can be queried using this ID.
+
+## Features
+- RESTful API for task submission and status query
+- Configurable maximum concurrent tasks (default: 30)
+- Integrated with Addax core Engine for direct job execution
+- Supports command-line and environment variable concurrency settings
+- Startup/shutdown script with background mode support
+
+## HTTP API
+
+### 1. Submit Task
+- URL: `/api/submit`
+- Method: POST
+- Request Example:
+```json
+{
+    "name": "example-job",
+    "job": "{...job json...}",
+    "jvm": {"Xmx": "2G"}
+}
+```
+- Response Example:
+```json
+{
+    "taskId": "xxxx-xxxx-xxxx"
+}
+```
+- If concurrency limit is reached:
+```json
+{
+    "error": "ERROR: Maximum number of concurrent tasks reached."
+}
+```
+
+### 2. Query Task Status
+- URL: `/api/status/{taskId}`
+- Method: GET
+- Response Example:
+```json
+{
+    "taskId": "xxxx-xxxx-xxxx",
+    "status": "SUCCESS",
+    "result": "Job example-job executed.",
+    "error": null
+}
+```
+
+## Start and Stop
+
+Use the script `core/src/main/bin/addax-server.sh` to start and stop the service.
+
+### Start Service
+```bash
+./addax-server.sh start
+```
+
+### Set Max Concurrency (e.g., 50) and Run in Background
+```bash
+./addax-server.sh start -p 50 --daemon
+```
+
+### Stop Service
+```bash
+./addax-server.sh stop
+```
+
+## Concurrency Configuration
+- Command-line `-p` or `--parallel` has highest priority
+- Environment variable `ADDAX_SERVER_PARALLEL` is next
+- Default concurrency is 30
+
+## Dependencies
+- Minimal Spring Boot Web components
+- Depends on core module Engine class
+
+## Notes
+- Ensure the job parameter is a valid Addax job JSON
+- High concurrency may impact system performance
+
+---
+For more help, refer to other documentation or contact the project maintainers.
+

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -12,15 +12,13 @@ The Server module provides HTTP interfaces for submitting and managing data coll
 ## HTTP API
 
 ### 1. Submit Task
-- URL: `/api/submit`
+- URL: `/api/submit?k1=v1&k2=v2`
 - Method: POST
 - Request Example:
-```json
-{
-    "name": "example-job",
-    "job": "{...job json...}",
-    "jvm": {"Xmx": "2G"}
-}
+```shell
+curl 'http://localhost:10601/api/submit?jobName=example-job' \
+-H 'Content-Type: application/json' \
+-d @job/job.json
 ```
 - Response Example:
 ```json
@@ -36,7 +34,7 @@ The Server module provides HTTP interfaces for submitting and managing data coll
 ```
 
 ### 2. Query Task Status
-- URL: `/api/status/{taskId}`
+- URL: `/api/status?taskId={taskId}`
 - Method: GET
 - Response Example:
 ```json
@@ -68,7 +66,7 @@ Use the script `core/src/main/bin/addax-server.sh` to start and stop the service
 ```
 
 ## Concurrency Configuration
-- Command-line `-p` or `--parallel` has highest priority
+- Command-line `-p` or `--parallel` has the highest priority
 - Environment variable `ADDAX_SERVER_PARALLEL` is next
 - Default concurrency is 30
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -3,6 +3,7 @@
 Server模块用于通过HTTP接口提交和管理数据采集任务。用户可通过POST方式提交JSON任务配置，服务端异步执行采集任务并返回唯一任务ID，随后可通过任务ID查询任务进度和结果。
 
 ## 功能简介
+
 - 提供RESTful接口，支持任务提交与状态查询
 - 支持最大并发任务数限制（默认30，可配置）
 - 集成Addax核心Engine，直接执行采集任务
@@ -12,15 +13,13 @@ Server模块用于通过HTTP接口提交和管理数据采集任务。用户可�
 ## HTTP接口说明
 
 ### 1. 提交任务
-- URL: `/api/submit`
+- URL: `/api/submit?k1=v1&k2=v2`
 - 方法: POST
 - 请求体示例：
-```json
-{
-    "name": "example-job",
-    "job": "{...job json...}",
-    "jvm": {"Xmx": "2G"}
-}
+```shell
+curl 'http://localhost:10601/api/submit?jobName=example-job' \
+-H 'Content-Type: application/json' \
+-d @job/job.json
 ```
 - 返回示例：
 ```json
@@ -36,7 +35,7 @@ Server模块用于通过HTTP接口提交和管理数据采集任务。用户可�
 ```
 
 ### 2. 查询任务状态
-- URL: `/api/status/{taskId}`
+- URL: `/api/status?taskId={taskId}`
 - 方法: GET
 - 返回示例：
 ```json

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,85 @@
+# Server模块
+
+Server模块用于通过HTTP接口提交和管理数据采集任务。用户可通过POST方式提交JSON任务配置，服务端异步执行采集任务并返回唯一任务ID，随后可通过任务ID查询任务进度和结果。
+
+## 功能简介
+- 提供RESTful接口，支持任务提交与状态查询
+- 支持最大并发任务数限制（默认30，可配置）
+- 集成Addax核心Engine，直接执行采集任务
+- 支持命令行和环境变量设置并发数
+- 提供启动/停止脚本，支持后台运行
+
+## HTTP接口说明
+
+### 1. 提交任务
+- URL: `/api/submit`
+- 方法: POST
+- 请求体示例：
+```json
+{
+    "name": "example-job",
+    "job": "{...job json...}",
+    "jvm": {"Xmx": "2G"}
+}
+```
+- 返回示例：
+```json
+{
+    "taskId": "xxxx-xxxx-xxxx"
+}
+```
+- 当并发数达到上限时：
+```json
+{
+    "error": "ERROR: Maximum number of concurrent tasks reached."
+}
+```
+
+### 2. 查询任务状态
+- URL: `/api/status/{taskId}`
+- 方法: GET
+- 返回示例：
+```json
+{
+    "taskId": "xxxx-xxxx-xxxx",
+    "status": "SUCCESS",
+    "result": "Job example-job executed.",
+    "error": null
+}
+```
+
+## 启动与停止
+
+推荐使用脚本 `core/src/main/bin/addax-server.sh` 启动和停止服务。
+
+### 启动服务
+```bash
+./addax-server.sh start
+```
+
+### 设置最大并发数（如50）并后台运行
+```bash
+./addax-server.sh start -p 50 --daemon
+```
+
+### 停止服务
+```bash
+./addax-server.sh stop
+```
+
+## 并发数配置
+- 命令行参数 `-p` 或 `--parallel` 优先
+- 环境变量 `ADDAX_SERVER_PARALLEL` 其次
+- 默认并发数为30
+
+## 依赖说明
+- 仅依赖Spring Boot最小化Web组件
+- 依赖core模块的Engine类
+
+## 注意事项
+- 任务提交时请确保job参数为合法的Addax任务JSON
+- 并发数过高可能影响系统性能
+
+---
+如需更多帮助，请参考其他文档或联系项目维护者。
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
   - statsreport.md
   - transformer.md
   - plugin_development.md
+  - server.md
 
 extra:
   version:

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
         <module>plugin/writer/sybasewriter</module>
         <module>plugin/writer/tdenginewriter</module>
         <module>plugin/writer/txtfilewriter</module>
+        <module>server</module>
     </modules>
 
     <developers>

--- a/server/package.xml
+++ b/server/package.xml
@@ -1,0 +1,45 @@
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<assembly
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-component-1.1.2.xsd">
+    <id>release</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target/</directory>
+            <includes>
+                <include>${project.artifactId}-${project.version}.jar</include>
+            </includes>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.wgzhao.addax</groupId>
+        <artifactId>addax-all</artifactId>
+        <version>6.0.5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>server</artifactId>
+    <name>addax-server</name>
+    <description>Minimal HTTP Server for Addax using JDK HttpServer</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <!-- Skip javadoc generation for this lightweight module to simplify builds -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
+    <dependencies>
+        <!-- Depend on addax-core; core brings required runtime dependencies for job execution -->
+        <dependency>
+            <groupId>com.wgzhao.addax</groupId>
+            <artifactId>addax-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- Keep default packaging; assembly is handled at top-level if needed -->
+        </plugins>
+    </build>
+</project>

--- a/server/src/main/java/com/wgzhao/addax/server/AddaxServer.java
+++ b/server/src/main/java/com/wgzhao/addax/server/AddaxServer.java
@@ -39,7 +39,8 @@ import java.net.URLDecoder;
 /**
  * Minimal HTTP server using JDK HttpServer. Provides /api/submit and /api/status endpoints.
  */
-public class ServerApplication {
+public class AddaxServer
+{
     private static final int DEFAULT_PORT = 10601;
     private static final int DEFAULT_PARALLEL = 30;
 

--- a/server/src/main/java/com/wgzhao/addax/server/ServerApplication.java
+++ b/server/src/main/java/com/wgzhao/addax/server/ServerApplication.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.server;
+
+import com.wgzhao.addax.server.manager.TaskManager;
+import com.wgzhao.addax.server.service.TaskService;
+import com.wgzhao.addax.server.model.TaskInfo;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.Map;
+import java.util.HashMap;
+import java.net.URLDecoder;
+
+/**
+ * Minimal HTTP server using JDK HttpServer. Provides /api/submit and /api/status endpoints.
+ */
+public class ServerApplication {
+    private static final int DEFAULT_PORT = 10601;
+    private static final int DEFAULT_PARALLEL = 30;
+
+    /**
+     * Main entry. Accepts optional args: {@code -p|--parallel &lt;n&gt;} and {@code --port &lt;port&gt;}.
+     * @param args command line arguments
+     * @throws Exception on startup error
+     */
+    public static void main(String[] args) throws Exception {
+        int port = DEFAULT_PORT;
+        int parallel = DEFAULT_PARALLEL;
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "-p":
+                case "--parallel":
+                    if (i + 1 < args.length) {
+                        try { parallel = Integer.parseInt(args[++i]); } catch (NumberFormatException ignored) {}
+                    }
+                    break;
+                case "--port":
+                    if (i + 1 < args.length) {
+                        try { port = Integer.parseInt(args[++i]); } catch (NumberFormatException ignored) {}
+                    }
+                    break;
+                default:
+                    // ignore
+            }
+        }
+
+        TaskManager.setMaxConcurrentTasks(parallel);
+        ExecutorService executor = Executors.newCachedThreadPool();
+        TaskService taskService = new TaskService(executor);
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/api/submit", new SubmitHandler(taskService));
+        server.createContext("/api/status", new StatusHandler(taskService));
+        server.setExecutor(Executors.newFixedThreadPool(Math.max(2, parallel)));
+
+        System.out.println("Starting Addax minimal HTTP server on port " + port + " with maxParallel=" + parallel);
+        server.start();
+    }
+
+    static String readRequestBody(HttpExchange exchange) throws IOException {
+        InputStream in = exchange.getRequestBody();
+        byte[] data = in.readAllBytes();
+        return new String(data, StandardCharsets.UTF_8);
+    }
+
+    static void writeJsonResponse(HttpExchange exchange, int statusCode, String json) throws IOException {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    static Map<String, String> parseQueryParams(String query) throws IOException {
+        Map<String, String> params = new HashMap<>();
+        if (query == null || query.isEmpty()) return params;
+        String[] pairs = query.split("&");
+        for (String p : pairs) {
+            int idx = p.indexOf('=');
+            if (idx > 0) {
+                String k = URLDecoder.decode(p.substring(0, idx), StandardCharsets.UTF_8.name());
+                String v = URLDecoder.decode(p.substring(idx + 1), StandardCharsets.UTF_8.name());
+                params.put(k, v);
+            } else if (!p.isEmpty()) {
+                String k = URLDecoder.decode(p, StandardCharsets.UTF_8.name());
+                params.put(k, "");
+            }
+        }
+        return params;
+    }
+
+    static class SubmitHandler implements HttpHandler {
+        private final TaskService taskService;
+        SubmitHandler(TaskService taskService) { this.taskService = taskService; }
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String body = readRequestBody(exchange); // job JSON
+            Map<String, String> params = parseQueryParams(exchange.getRequestURI().getQuery());
+            try {
+                String result = taskService.submitTask(body, params);
+                if (result.startsWith("ERROR:")) {
+                    writeJsonResponse(exchange, 429, "{\"error\":\"" + escapeJson(result) + "\"}");
+                } else {
+                    writeJsonResponse(exchange, 200, "{\"taskId\":\"" + escapeJson(result) + "\"}");
+                }
+            } catch (Exception e) {
+                writeJsonResponse(exchange, 500, "{\"error\":\"" + escapeJson(e.getMessage()) + "\"}");
+            }
+        }
+    }
+
+    static class StatusHandler implements HttpHandler {
+        private final TaskService taskService;
+        StatusHandler(TaskService taskService) { this.taskService = taskService; }
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String query = exchange.getRequestURI().getQuery();
+            String taskId = null;
+            if (query != null) {
+                for (String kv : query.split("&")) {
+                    String[] parts = kv.split("=", 2);
+                    if (parts.length == 2 && "taskId".equals(parts[0])) {
+                        taskId = parts[1];
+                        break;
+                    }
+                }
+            }
+            if (taskId == null) {
+                writeJsonResponse(exchange, 400, "{\"error\":\"missing taskId\"}");
+                return;
+            }
+            TaskInfo info = taskService.getTaskInfo(taskId);
+            if (info == null) {
+                writeJsonResponse(exchange, 404, "{\"error\":\"task not found\"}");
+                return;
+            }
+            String json = "{\"taskId\":\"" + escapeJson(info.getTaskId()) + "\"," +
+                    "\"status\":\"" + info.getStatus().name() + "\"," +
+                    "\"result\":\"" + escapeJson(info.getResult()) + "\"," +
+                    "\"error\":\"" + escapeJson(info.getError()) + "\"}";
+            writeJsonResponse(exchange, 200, json);
+        }
+    }
+
+    static String escapeJson(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+    }
+}

--- a/server/src/main/java/com/wgzhao/addax/server/controller/TaskController.java
+++ b/server/src/main/java/com/wgzhao/addax/server/controller/TaskController.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.server.controller;
+
+/**
+ * Deprecated placeholder. The server module no longer uses Spring MVC controllers.
+ * HTTP endpoints are implemented in ServerApplication using the JDK HttpServer.
+ */
+public final class TaskController {
+    private TaskController() { /* utility class - not instantiable */ }
+}

--- a/server/src/main/java/com/wgzhao/addax/server/manager/TaskManager.java
+++ b/server/src/main/java/com/wgzhao/addax/server/manager/TaskManager.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.server.manager;
+
+import com.wgzhao.addax.server.model.TaskInfo;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.Map;
+
+/**
+ * Manages the lifecycle, status, and results of tasks.
+ * Controls the maximum number of concurrent running tasks.
+ */
+public class TaskManager {
+    private static final Map<String, TaskInfo> tasks = new ConcurrentHashMap<>();
+    private static Semaphore semaphore = new Semaphore(30); // Default max concurrent tasks
+
+    /**
+     * Set the maximum number of concurrent running tasks.
+     * @param maxTasks maximum concurrent tasks
+     */
+    public static void setMaxConcurrentTasks(int maxTasks) {
+        semaphore = new Semaphore(maxTasks);
+    }
+
+    /**
+     * Try to acquire a slot for a new running task.
+     * @return true if acquired, false if limit reached
+     */
+    public static boolean tryAcquireSlot() {
+        return semaphore.tryAcquire();
+    }
+
+    /**
+     * Release a slot when a task finishes.
+     */
+    public static void releaseSlot() {
+        semaphore.release();
+    }
+
+    /**
+     * Add a new task to the manager.
+     * @param taskInfo task information
+     */
+    public static void addTask(TaskInfo taskInfo) {
+        tasks.put(taskInfo.getTaskId(), taskInfo);
+    }
+
+    /**
+     * Get task information by task ID.
+     * @param taskId task ID
+     * @return TaskInfo or null if not found
+     */
+    public static TaskInfo getTask(String taskId) {
+        return tasks.get(taskId);
+    }
+
+    /**
+     * Update the status and result of a task.
+     * @param taskId task ID
+     * @param status task status
+     * @param result result string
+     * @param error error message
+     */
+    public static void updateTask(String taskId, TaskInfo.Status status, String result, String error) {
+        TaskInfo info = tasks.get(taskId);
+        if (info != null) {
+            info.setStatus(status);
+            info.setResult(result);
+            info.setError(error);
+        }
+    }
+}

--- a/server/src/main/java/com/wgzhao/addax/server/model/TaskInfo.java
+++ b/server/src/main/java/com/wgzhao/addax/server/model/TaskInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.server.model;
+
+public class TaskInfo {
+    public enum Status {
+        RUNNING, SUCCESS, FAILED
+    }
+
+    private String taskId;
+    private Status status;
+    private String result;
+    private String error;
+
+    public TaskInfo(String taskId) {
+        this.taskId = taskId;
+        this.status = Status.RUNNING;
+    }
+
+    // getters and setters
+    public String getTaskId() { return taskId; }
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+    public String getResult() { return result; }
+    public void setResult(String result) { this.result = result; }
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+}

--- a/server/src/main/java/com/wgzhao/addax/server/service/TaskService.java
+++ b/server/src/main/java/com/wgzhao/addax/server/service/TaskService.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.server.service;
+
+import com.wgzhao.addax.server.manager.TaskManager;
+import com.wgzhao.addax.server.model.TaskInfo;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Service for submitting and executing tasks using a provided ExecutorService.
+ * This implementation uses only JDK classes (no external web framework) and
+ * invokes Addax Engine via reflection.
+ */
+public class TaskService {
+    private final ExecutorService executor;
+
+    /**
+     * Construct TaskService with an ExecutorService used to run tasks asynchronously.
+     * @param executor ExecutorService instance
+     */
+    public TaskService(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Submit a task with explicit parameters. The job JSON must be provided in the body
+     * of the POST request. Other parameters (e.g. name, jvm) are provided as query params.
+     * This method accepts a raw jvmParam string (can be JSON object) and will try to parse it.
+     * @param name job name, may be null
+     * @param jobJson job JSON content from request body
+     * @param jvmParam optional jvm parameter string (JSON object or empty)
+     * @return taskId if accepted, or an error string starting with "ERROR:"
+     */
+    public String submitTask(String jobJson, Map<String, String> params) {
+
+        // currently name and jvmMap are passed to task execution; jvmMap is not used to spawn JVMs
+        if (!TaskManager.tryAcquireSlot()) {
+            return "ERROR: Maximum number of concurrent tasks reached.";
+        }
+        String taskId = UUID.randomUUID().toString();
+        TaskInfo info = new TaskInfo(taskId);
+        TaskManager.addTask(info);
+
+        executor.submit(() -> runTask(taskId, "addax", jobJson));
+        return taskId;
+    }
+
+    /**
+     * Backwards compatible method that expects the old wrapper JSON. Maintained for internal use only.
+     * @param body old wrapper body
+     * @return taskId or error
+     */
+//    public String submitTaskFromJson(String body) {
+//        // try to extract top-level job and name if client used old format
+//        Map<String, String> top = parseTopLevelJson(body);
+//        String name = top.get("name");
+//        String job = top.get("job");
+//        String jvm = top.get("jvm");
+//        return submitTask(name, job, jvm);
+//    }
+
+    /**
+     * Get task information.
+     * @param taskId task id
+     * @return TaskInfo or null
+     */
+    public TaskInfo getTaskInfo(String taskId) {
+        return TaskManager.getTask(taskId);
+    }
+
+    private void runTask(String taskId, String name, String jobJson) {
+        java.nio.file.Path tmp = null;
+        try {
+            // write job JSON to a temporary file
+            tmp = java.nio.file.Files.createTempFile("addax-job-", ".json");
+            java.nio.file.Files.writeString(tmp, jobJson == null ? "" : jobJson, java.nio.charset.StandardCharsets.UTF_8);
+
+            // Call Engine.entry(String[] args) to run job without invoking System.exit
+            Class<?> engineClass = Class.forName("com.wgzhao.addax.core.Engine");
+            try {
+                Method entryMethod = engineClass.getMethod("entry", String[].class);
+                String[] args = new String[]{"-job", tmp.toString()};
+                // invoke static method; cast to Object to avoid varargs expansion
+                entryMethod.invoke(null, (Object) args);
+            } catch (NoSuchMethodException nsme) {
+                // Fallback: try calling main(String[]), but main calls System.exit so avoid it.
+                throw new RuntimeException("Engine.entry(String[]) not found; cannot safely invoke Engine.main from server process.", nsme);
+            }
+
+            TaskManager.updateTask(taskId, TaskInfo.Status.SUCCESS, "Job " + name + " executed.", null);
+        } catch (Throwable e) {
+            TaskManager.updateTask(taskId, TaskInfo.Status.FAILED, null, e.toString());
+        } finally {
+            // cleanup temp file
+            if (tmp != null) {
+                try { java.nio.file.Files.deleteIfExists(tmp); } catch (Exception ignored) {}
+            }
+            TaskManager.releaseSlot();
+        }
+    }
+}


### PR DESCRIPTION

This PR introduces a new `server` module that provides a lightweight HTTP API for Addax job submission and status tracking.  

- Implements a minimal Java HttpServer for `/api/submit` (POST) and `/api/status?taskId={taskId}` (GET) endpoints  
- Uses reflection to invoke `Engine.entry(String[])` with job config written to a temporary file  
- Controls concurrency via Semaphore; tracks task state in-memory  
