### PR TITLE
[bugfix][plugin][elastcisearchreader]  Fix ES query serialization and avoid adding type to search path

### DIFF
--- a/plugin/reader/elasticsearchreader/src/main/java/com/wgzhao/addax/plugin/reader/elasticsearchreader/ESKey.java
+++ b/plugin/reader/elasticsearchreader/src/main/java/com/wgzhao/addax/plugin/reader/elasticsearchreader/ESKey.java
@@ -22,6 +22,7 @@ package com.wgzhao.addax.plugin.reader.elasticsearchreader;
 import com.wgzhao.addax.core.util.Configuration;
 import io.searchbox.params.SearchType;
 import org.apache.commons.lang3.StringUtils;
+import com.google.gson.Gson;
 
 import java.util.HashMap;
 import java.util.List;
@@ -112,7 +113,21 @@ public final class ESKey
 
     public static String getQuery(Configuration conf)
     {
-        return conf.getConfiguration(ESKey.SEARCH_KEY).toString();
+        if (conf == null) {
+            return null;
+        }
+        // The search configuration may be provided as a raw JSON string or as a nested configuration/map.
+        // If it's a string, return it directly. Otherwise, serialize the object to a JSON string so
+        // Jest receives valid JSON (Configuration.toString() may not produce valid ES JSON).
+        Object searchObj = conf.get(SEARCH_KEY);
+        if (searchObj == null) {
+            return null;
+        }
+        if (searchObj instanceof String) {
+            return (String) searchObj;
+        }
+        // use Gson to serialize map/objects to a valid JSON string
+        return new Gson().toJson(searchObj);
     }
 
     public static String getScroll(Configuration conf)

--- a/plugin/reader/elasticsearchreader/src/main/java/com/wgzhao/addax/plugin/reader/elasticsearchreader/EsReader.java
+++ b/plugin/reader/elasticsearchreader/src/main/java/com/wgzhao/addax/plugin/reader/elasticsearchreader/EsReader.java
@@ -131,7 +131,7 @@ public class EsReader
         @Override
         public void destroy()
         {
-            log.info("============elasticsearch reader job destroy=================");
+            //
         }
     }
 


### PR DESCRIPTION
## Commit description Summary

- Ensure the search request body sent to Elasticsearch is valid JSON and matches the user-provided search configuration.
- Stop appending the legacy type segment into the search path (use /{index}/_search). This avoids incorrect pathing on ES 7+ where types are deprecated and can cause missed hits.
- Add useful logging to help debug endpoint, query and failed responses.

## Motivation

- Previously `ESKey.getQuery(...)` used the configuration object’s `toString()` (or similar) which did not necessarily produce a valid ES JSON body. As a result, queries that worked with curl (sending raw JSON) returned no results when run through the plugin.
- Some environments still supply `type` in configuration; adding type to the request path can result in requests to `/index/type/_search`, which is deprecated and may not route to the expected documents in newer ES versions. Removing type from the path and always using `/{index}/_search` makes behavior consistent with curl and modern ES.
Extra logging helps confirm which endpoint is contacted and what JSON payload is being sent, and prints ES response details when a request fails.