### PR TITLE
[bugfix][plugin][paimonwriter] Fix paimon writer data loss

### DIFF
--- a/plugin/writer/paimonwriter/src/main/java/com/wgzhao/addax/plugin/writer/paimonwriter/PaimonWriter.java
+++ b/plugin/writer/paimonwriter/src/main/java/com/wgzhao/addax/plugin/writer/paimonwriter/PaimonWriter.java
@@ -221,7 +221,7 @@ public class PaimonWriter
 
                 columnList = table.rowType().getFields();
                 typeList = table.rowType().getFieldTypes();
-                writeBuilder = table.newBatchWriteBuilder().withOverwrite();
+                writeBuilder = table.newBatchWriteBuilder();
             }
             catch (Exception e) {
                 log.error("init paimon error", e);


### PR DESCRIPTION
withOverwrite() should only be called once before writing, not per batch. Using it in every batch will cause data loss as it resets the table state

https://paimon.apache.org/docs/1.2/program-api/java-api/#batch-write

to close(#1395)