### PR TITLE
fix: excludeColumn config not working due to quoted column name mismatch

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/OriginalConfPretreatmentUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/OriginalConfPretreatmentUtil.java
@@ -218,17 +218,17 @@ public final class OriginalConfPretreatmentUtil
 
                 if (!excludeColumns.isEmpty()) {
                     // Get all columns of table and exclude the excludeColumns
+                    // Note: getTableColumns returns already-quoted column names,
+                    // so we need to quote excludeColumns the same way for comparison
                     List<String> allColumns = new ArrayList<>(DBUtil.getTableColumns(dataBaseType, jdbcUrl, username, password, tableName));
-                    // Note: Consider if table column comparison should be case-insensitive
-                    allColumns.removeAll(excludeColumns);
-                    originalConfig.set(Key.COLUMN_LIST, allColumns);
-
-                    // Each column in allColumns should be quoted appropriately
-                    var quotedColumns = allColumns.stream()
+                    var quotedExcludeColumns = excludeColumns.stream()
                             .map(r -> dataBaseType.quoteColumnName(r, true))
                             .toList();
+                    allColumns.removeAll(quotedExcludeColumns);
+                    originalConfig.set(Key.COLUMN_LIST, allColumns);
 
-                    originalConfig.set(Key.COLUMN, String.join(",", quotedColumns));
+                    // allColumns are already quoted, no need to quote again
+                    originalConfig.set(Key.COLUMN, String.join(",", allColumns));
                 } else {
                     originalConfig.set(Key.COLUMN, "*");
                 }


### PR DESCRIPTION
The excludeColumn feature failed silently because:

1. DBUtil.getTableColumns() returns already-quoted column names (e.g. `col_name`), but excludeColumns from user config are unquoted (e.g. col_name). The removeAll() comparison always failed since they never matched.

2. The allColumns were then unnecessarily double-quoted when building the final column string.

Fix: quote excludeColumns before comparison, and skip redundant re-quoting of allColumns since they are already quoted from getTableColumns().

<!--
Please fill in the sections below when opening a pull request. This template is
based on GitHub community best practices and adapted for this project.
-->

<!-- Title -->
<!-- Use a short, descriptive title: e.g. "[FIX] Avoid invalid BSON field names in MongoDB writer" -->

## Summary
<!-- Provide a short description of what this PR changes and why. -->


## Related Issue(s)
<!-- Link to any existing issues this PR addresses: Fixes #123, Relates to #456 -->


## What type of change is this?
<!-- Check one or more boxes: -->
- [ ] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)


## Changes
<!-- Describe the main changes in this PR. Keep each change short and focused. -->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->


## How has this been tested?
Please include steps to reproduce and verify the changes locally. Examples:

- Automated tests added: `module/src/test/...` (describe)
- Manual steps:
  1. Build project: `mvn -DskipTests install` (from repo root)
  2. Run writer module build: `mvn -DskipTests package -f plugin/writer/mongodbwriter/pom.xml`
  3. Start a local MongoDB and run the job (or use the provided test harness)
  4. Verify the document written contains nested field and array as expected

Include relevant logs or small snippets if helpful.


## Checklist (required)
- [ ] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable).
- [ ] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [ ] I have not added any secrets or credentials.
- [ ] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.


## Checklist for maintainers / reviewers (recommended)
- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [ ] Evaluate whether the change requires a migration note.


## Release notes
<!-- Optional: short note that will be included in release notes. -->


## Breaking changes / Migration
<!-- If this PR introduces breaking changes, describe the impact and recommended migration steps. -->


## Security
If this PR fixes a security vulnerability, DO NOT include exploit details in this public description.
Instead, contact the maintainers by email or follow the project's security disclosure process.


## Additional context
<!-- Add any other context or screenshots about the PR here. -->


---

<!-- Guidance for PR authors: keep the template short and actionable. -->

*Tips:*
- Use a concise, prefixed title like `[FIX]`, `[FEATURE]`, `[DOC]`, or `[BREAKING]`.
- Group related changes into a single logical PR where possible.
- If the change affects end-users, add a clear `Release notes` entry and a migration paragraph.
- For large or risky changes, include a short test plan and a rollback plan.

