### PR TITLE
[FIX] Improve mongodbreader wildcard split planning and query-aware fallback

### DIFF
--- a/plugin/reader/mongodbreader/src/main/java/com/wgzhao/addax/plugin/reader/mongodbreader/util/CollectionExpandUtil.java
+++ b/plugin/reader/mongodbreader/src/main/java/com/wgzhao/addax/plugin/reader/mongodbreader/util/CollectionExpandUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.plugin.reader.mongodbreader.util;
+
+import com.wgzhao.addax.core.exception.AddaxException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
+
+public final class CollectionExpandUtil
+{
+    private static final Pattern PATTERN = Pattern.compile("(\\w+)\\[(\\d+)-(\\d+)](.*)");
+
+    private CollectionExpandUtil() {}
+
+    public static List<String> expandCollectionNames(String collectionExpr)
+    {
+        if (collectionExpr == null || collectionExpr.trim().isEmpty()) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE, "The configuration [connection.collection] is required.");
+        }
+
+        String expr = collectionExpr.trim();
+        if (expr.contains(",")) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    "The configuration [connection.collection] only supports a single collection or one wildcard range expression.");
+        }
+
+        Matcher matcher = PATTERN.matcher(expr);
+        if (!matcher.matches()) {
+            return List.of(expr);
+        }
+
+        String start = matcher.group(2).trim();
+        String end = matcher.group(3).trim();
+
+        if (Integer.parseInt(start) > Integer.parseInt(end)) {
+            String temp = start;
+            start = end;
+            end = temp;
+        }
+
+        int paddingLength = start.length();
+        String prefix = matcher.group(1).trim();
+        String suffix = matcher.group(4).trim();
+
+        List<String> collections = new ArrayList<>();
+        for (int k = Integer.parseInt(start); k <= Integer.parseInt(end); k++) {
+            String collection;
+            if (start.startsWith("0")) {
+                collection = prefix + String.format("%0" + paddingLength + "d", k) + suffix;
+            }
+            else {
+                collection = prefix + k + suffix;
+            }
+            collections.add(collection);
+        }
+        return collections;
+    }
+}
+

--- a/plugin/reader/mongodbreader/src/main/java/com/wgzhao/addax/plugin/reader/mongodbreader/util/CollectionSplitUtil.java
+++ b/plugin/reader/mongodbreader/src/main/java/com/wgzhao/addax/plugin/reader/mongodbreader/util/CollectionSplitUtil.java
@@ -23,6 +23,7 @@ package com.wgzhao.addax.plugin.reader.mongodbreader.util;
 import com.mongodb.MongoCommandException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.util.Configuration;
@@ -31,7 +32,9 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.wgzhao.addax.core.base.Key.CONNECTION;
 import static com.wgzhao.addax.core.base.Key.DATABASE;
@@ -39,7 +42,6 @@ import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
 
 public class CollectionSplitUtil
 {
-
     private CollectionSplitUtil() {}
 
     public static List<Configuration> doSplit(Configuration originalSliceConfig, int adviceNumber, MongoClient mongoClient)
@@ -50,24 +52,61 @@ public class CollectionSplitUtil
         Configuration connConf = originalSliceConfig.getConfiguration(CONNECTION);
         String dbName = connConf.getString(DATABASE);
 
-        String collName = connConf.getString(KeyConstant.MONGO_COLLECTION_NAME);
+        String collectionExpr = connConf.getString(KeyConstant.MONGO_COLLECTION_NAME);
+        Document queryFilter = parseQueryFilter(originalSliceConfig.getString(KeyConstant.MONGO_QUERY));
 
-        if (null == dbName || dbName.isEmpty() || null == collName || collName.isEmpty() || mongoClient == null) {
+        if (null == dbName || dbName.isEmpty() || null == collectionExpr || collectionExpr.isEmpty() || mongoClient == null) {
             throw AddaxException.asAddaxException(ILLEGAL_VALUE,
                     ILLEGAL_VALUE.getDescription());
         }
 
-        boolean isObjectId = isPrimaryIdObjectId(mongoClient, dbName, collName);
+        List<String> expandedCollections = CollectionExpandUtil.expandCollectionNames(collectionExpr);
+        List<String> availableCollections = getAvailableCollections(mongoClient, dbName, expandedCollections);
 
-        List<Range> rangeList = doSplitCollection(adviceNumber, mongoClient, dbName, collName, isObjectId);
-        for (Range range : rangeList) {
-            Configuration conf = originalSliceConfig.clone();
-            conf.set(KeyConstant.LOWER_BOUND, range.lowerBound);
-            conf.set(KeyConstant.UPPER_BOUND, range.upperBound);
-            conf.set(KeyConstant.IS_OBJECT_ID, isObjectId);
-            confList.add(conf);
+        if (availableCollections.isEmpty()) {
+            return confList;
         }
+
+        Map<String, Long> docCountCache = new HashMap<>();
+        Map<String, Integer> splitPlan = allocateSplitNumberByDocCount(
+                mongoClient,
+                dbName,
+                availableCollections,
+                queryFilter,
+                docCountCache,
+                Math.max(adviceNumber, 1));
+
+        for (String collName : availableCollections) {
+            boolean isObjectId = isPrimaryIdObjectId(mongoClient, dbName, collName);
+            int splitNumber = splitPlan.getOrDefault(collName, 1);
+
+            long docCount = docCountCache.getOrDefault(collName, -1L);
+            List<Range> rangeList = doSplitCollection(splitNumber, mongoClient, dbName, collName, isObjectId, queryFilter, docCount);
+            for (Range range : rangeList) {
+                Configuration conf = originalSliceConfig.clone();
+                conf.set(CONNECTION + "." + KeyConstant.MONGO_COLLECTION_NAME, collName);
+                conf.set(KeyConstant.LOWER_BOUND, range.lowerBound);
+                conf.set(KeyConstant.UPPER_BOUND, range.upperBound);
+                conf.set(KeyConstant.IS_OBJECT_ID, isObjectId);
+                confList.add(conf);
+            }
+        }
+
         return confList;
+    }
+
+    private static List<String> getAvailableCollections(MongoClient mongoClient, String dbName, List<String> expandedCollections)
+    {
+        MongoDatabase database = mongoClient.getDatabase(dbName);
+        List<String> existingNames = database.listCollectionNames().into(new ArrayList<>());
+        List<String> availableCollections = new ArrayList<>();
+
+        for (String collection : expandedCollections) {
+            if (existingNames.contains(collection)) {
+                availableCollections.add(collection);
+            }
+        }
+        return availableCollections;
     }
 
     private static boolean isPrimaryIdObjectId(MongoClient mongoClient, String dbName, String collName)
@@ -75,17 +114,104 @@ public class CollectionSplitUtil
         MongoDatabase database = mongoClient.getDatabase(dbName);
         MongoCollection<Document> col = database.getCollection(collName);
         Document doc = col.find().limit(1).first();
-        assert doc != null;
+        if (doc == null) {
+            return false;
+        }
         Object id = doc.get(KeyConstant.MONGO_PRIMARY_ID);
         return id instanceof ObjectId;
     }
 
+    private static Map<String, Integer> allocateSplitNumberByDocCount(MongoClient mongoClient,
+            String dbName,
+            List<String> collections,
+            Document queryFilter,
+            Map<String, Long> docCountCache,
+            int adviceNumber)
+    {
+        Map<String, Integer> splitPlan = new HashMap<>();
+        if (collections.isEmpty()) {
+            return splitPlan;
+        }
+
+        int totalCollectionCount = collections.size();
+        int totalTaskCount = Math.max(adviceNumber, totalCollectionCount);
+        int extraTaskCount = totalTaskCount - totalCollectionCount;
+
+        for (String collection : collections) {
+            splitPlan.put(collection, 1);
+        }
+
+        // No extra split is needed, avoid any expensive counting.
+        if (extraTaskCount <= 0) {
+            return splitPlan;
+        }
+
+        long totalDocCount = 0L;
+        for (String collection : collections) {
+            long count = Math.max(fetchDocCount(mongoClient, dbName, collection, queryFilter), 0L);
+            docCountCache.put(collection, count);
+            totalDocCount += count;
+        }
+
+        if (totalDocCount == 0L) {
+            for (int i = 0; i < extraTaskCount; i++) {
+                String collection = collections.get(i % totalCollectionCount);
+                splitPlan.put(collection, splitPlan.get(collection) + 1);
+            }
+            return splitPlan;
+        }
+
+        List<Quota> quotas = new ArrayList<>();
+        int assigned = 0;
+        for (String collection : collections) {
+            double exact = 1.0D * extraTaskCount * docCountCache.get(collection) / totalDocCount;
+            int floor = (int) Math.floor(exact);
+            assigned += floor;
+            splitPlan.put(collection, splitPlan.get(collection) + floor);
+            quotas.add(new Quota(collection, exact - floor));
+        }
+
+        int remain = extraTaskCount - assigned;
+        quotas.sort((o1, o2) -> Double.compare(o2.remainder, o1.remainder));
+        for (int i = 0; i < remain; i++) {
+            Quota quota = quotas.get(i % quotas.size());
+            splitPlan.put(quota.collection, splitPlan.get(quota.collection) + 1);
+        }
+        return splitPlan;
+    }
+
+    private static long fetchDocCount(MongoClient mongoClient, String dbName, String collName, Document queryFilter)
+    {
+        MongoDatabase database = mongoClient.getDatabase(dbName);
+        try {
+            if (hasQueryFilter(queryFilter)) {
+                return database.getCollection(collName).countDocuments(queryFilter);
+            }
+            Document result = database.runCommand(new Document("collStats", collName));
+            Object count = result.get("count");
+            if (count instanceof Integer) {
+                return ((Integer) count).longValue();
+            }
+            if (count instanceof Long) {
+                return (Long) count;
+            }
+            if (count instanceof Double) {
+                return ((Double) count).longValue();
+            }
+            return 0L;
+        }
+        catch (Exception e) {
+            return 0L;
+        }
+    }
+
     // split the collection into multiple chunks, each chunk specifies a range
     private static List<Range> doSplitCollection(int adviceNumber, MongoClient mongoClient,
-            String dbName, String collName, boolean isObjectId)
+            String dbName, String collName, boolean isObjectId, Document queryFilter, long knownDocCount)
     {
 
         MongoDatabase database = mongoClient.getDatabase(dbName);
+        MongoCollection<Document> col = database.getCollection(collName);
         List<Range> rangeList = new ArrayList<>();
         if (adviceNumber == 1) {
             Range range = new Range();
@@ -95,11 +221,22 @@ public class CollectionSplitUtil
             return rangeList;
         }
 
-        Document result = database.runCommand(new Document("collStats", collName));
-        int docCount = result.getInteger("count");
+        long docCount = knownDocCount >= 0 ? knownDocCount : fetchDocCount(mongoClient, dbName, collName, queryFilter);
         if (docCount == 0) {
             return rangeList;
         }
+        if (adviceNumber > docCount) {
+            adviceNumber = (int) docCount;
+        }
+        if (adviceNumber <= 1) {
+            Range range = new Range();
+            range.lowerBound = "min";
+            range.upperBound = "max";
+            rangeList.add(range);
+            return rangeList;
+        }
+
+        Document result = database.runCommand(new Document("collStats", collName));
         int avgObjSize = 1;
         Object avgObjSizeObj = result.get("avgObjSize");
         if (avgObjSizeObj instanceof Integer) {
@@ -109,72 +246,71 @@ public class CollectionSplitUtil
             avgObjSize = ((Double) avgObjSizeObj).intValue();
         }
         int splitPointCount = adviceNumber - 1;
-        int chunkDocCount = docCount / adviceNumber;
+        long chunkDocCount = docCount / adviceNumber;
         ArrayList<Object> splitPoints = new ArrayList<>();
+        boolean supportSplitVector = !hasQueryFilter(queryFilter);
 
         // test if user has splitVector role(clusterManager)
-        boolean supportSplitVector = true;
-        try {
-            database.runCommand(new Document("splitVector", dbName + "." + collName)
-                    .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
-                    .append("force", true));
-        }
-        catch (MongoCommandException e) {
-            if (e.getErrorCode() == KeyConstant.MONGO_UNAUTHORIZED_ERR_CODE ||
-                    e.getErrorCode() == KeyConstant.MONGO_ILLEGAL_OP_ERR_CODE ||
-                    e.getErrorCode() == KeyConstant.MONGO_COMMAND_NOT_FOUND_CODE) {
-                supportSplitVector = false;
+        if (supportSplitVector) {
+            try {
+                database.runCommand(new Document("splitVector", dbName + "." + collName)
+                        .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
+                        .append("force", true));
+            }
+            catch (MongoCommandException e) {
+                if (e.getErrorCode() == KeyConstant.MONGO_UNAUTHORIZED_ERR_CODE ||
+                        e.getErrorCode() == KeyConstant.MONGO_ILLEGAL_OP_ERR_CODE ||
+                        e.getErrorCode() == KeyConstant.MONGO_COMMAND_NOT_FOUND_CODE) {
+                    supportSplitVector = false;
+                }
+                else {
+                    supportSplitVector = false;
+                }
             }
         }
 
         if (supportSplitVector) {
-            boolean forceMedianSplit = false;
-            int maxChunkSize = (docCount / splitPointCount - 1) * 2 * avgObjSize / (1024 * 1024);
-            //int maxChunkSize = (chunkDocCount - 1) * 2 * avgObjSize / (1024 * 1024)
-            if (maxChunkSize < 1) {
-                forceMedianSplit = true;
-            }
-            if (!forceMedianSplit) {
-                result = database.runCommand(new Document("splitVector", dbName + "." + collName)
-                        .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
-                        .append("maxChunkSize", maxChunkSize)
-                        .append("maxSplitPoints", adviceNumber - 1));
-            }
-            else {
-                result = database.runCommand(new Document("splitVector", dbName + "." + collName)
-                        .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
-                        .append("force", true));
-            }
-            ArrayList<Document> splitKeys = result.get("splitKeys", ArrayList.class);
-
-            for (Document splitKey : splitKeys) {
-                Object id = splitKey.get(KeyConstant.MONGO_PRIMARY_ID);
-                if (isObjectId) {
-                    ObjectId oid = (ObjectId) id;
-                    splitPoints.add(oid.toHexString());
+            try {
+                boolean forceMedianSplit = false;
+                long maxChunkSize = (docCount / splitPointCount - 1) * 2L * avgObjSize / (1024 * 1024);
+                // splitVector can use storage metadata to avoid a full scan when query is absent.
+                if (maxChunkSize < 1) {
+                    forceMedianSplit = true;
+                }
+                if (!forceMedianSplit) {
+                    result = database.runCommand(new Document("splitVector", dbName + "." + collName)
+                            .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
+                            .append("maxChunkSize", maxChunkSize)
+                            .append("maxSplitPoints", adviceNumber - 1));
                 }
                 else {
-                    splitPoints.add(id);
+                    result = database.runCommand(new Document("splitVector", dbName + "." + collName)
+                            .append("keyPattern", new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
+                            .append("force", true));
                 }
+                List<?> splitKeys = result.get("splitKeys", List.class);
+
+                if (splitKeys != null) {
+                    for (Object splitKeyObj : splitKeys) {
+                        Document splitKey = (Document) splitKeyObj;
+                        Object id = splitKey.get(KeyConstant.MONGO_PRIMARY_ID);
+                        if (isObjectId) {
+                            ObjectId oid = (ObjectId) id;
+                            splitPoints.add(oid.toHexString());
+                        }
+                        else {
+                            splitPoints.add(id);
+                        }
+                    }
+                }
+            }
+            catch (Exception e) {
+                splitPoints.clear();
             }
         }
-        else {
-            int skipCount = chunkDocCount;
-            MongoCollection<Document> col = database.getCollection(collName);
 
-            for (int i = 0; i < splitPointCount; i++) {
-                Document doc = col.find().skip(skipCount).limit(chunkDocCount).first();
-                assert doc != null;
-                Object id = doc.get(KeyConstant.MONGO_PRIMARY_ID);
-                if (isObjectId) {
-                    ObjectId oid = (ObjectId) id;
-                    splitPoints.add(oid.toHexString());
-                }
-                else {
-                    splitPoints.add(id);
-                }
-                skipCount += chunkDocCount;
-            }
+        if (splitPoints.isEmpty()) {
+            splitPoints.addAll(sampleSplitPointsSequentially(col, queryFilter, splitPointCount, chunkDocCount, isObjectId));
         }
 
         Object lastObjectId = "min";
@@ -191,6 +327,73 @@ public class CollectionSplitUtil
         rangeList.add(range);
 
         return rangeList;
+    }
+
+    private static List<Object> sampleSplitPointsSequentially(MongoCollection<Document> collection,
+            Document queryFilter,
+            int splitPointCount,
+            long chunkDocCount,
+            boolean isObjectId)
+    {
+        List<Object> splitPoints = new ArrayList<>();
+        if (splitPointCount <= 0 || chunkDocCount <= 0) {
+            return splitPoints;
+        }
+
+        Document filter = hasQueryFilter(queryFilter) ? queryFilter : new Document();
+        long nextSplitIndex = chunkDocCount + 1;
+        long currentIndex = 0;
+
+        // A single ordered cursor avoids repeated large-offset skips on oversized collections.
+        try (MongoCursor<Document> cursor = collection.find(filter)
+                .projection(new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
+                .sort(new Document(KeyConstant.MONGO_PRIMARY_ID, 1))
+                .batchSize(1024)
+                .iterator()) {
+            while (cursor.hasNext() && splitPoints.size() < splitPointCount) {
+                Document doc = cursor.next();
+                currentIndex++;
+                if (currentIndex < nextSplitIndex) {
+                    continue;
+                }
+
+                Object id = doc.get(KeyConstant.MONGO_PRIMARY_ID);
+                if (isObjectId) {
+                    splitPoints.add(((ObjectId) id).toHexString());
+                }
+                else {
+                    splitPoints.add(id);
+                }
+                nextSplitIndex += chunkDocCount;
+            }
+        }
+
+        return splitPoints;
+    }
+
+    private static Document parseQueryFilter(String query)
+    {
+        if (query == null || query.trim().isEmpty()) {
+            return null;
+        }
+        return Document.parse(query);
+    }
+
+    private static boolean hasQueryFilter(Document queryFilter)
+    {
+        return queryFilter != null && !queryFilter.isEmpty();
+    }
+}
+
+class Quota
+{
+    String collection;
+    double remainder;
+
+    Quota(String collection, double remainder)
+    {
+        this.collection = collection;
+        this.remainder = remainder;
     }
 }
 


### PR DESCRIPTION
## Summary
This PR improves MongoDB reader split behavior for wildcard collections and query-filtered reads.
It reduces split-stage overhead and keeps fallback splitting stable on very large collections.

## Related Issue(s)
N/A

## What type of change is this?
- [x] Bugfix
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes
- Added `CollectionExpandUtil` to support wildcard range expressions like `name[001-010]`.
- Updated `CollectionSplitUtil` to expand and validate candidate collections against existing names.
- Made split planning query-aware for per-collection allocation.
- Replaced skip-based fallback split-point search with a single ordered cursor sampling strategy.
- Avoided unnecessary repeated count scans when no extra split is needed.

## Motivation and Context
When reading wildcard collections with query filters, split planning could become expensive and unstable on very large datasets.
This change improves throughput predictability and reduces split-stage overhead while keeping current behavior compatible.

## How has this been tested?
- Manual steps:
  1. Build project module: `mvn package -pl :mongodbreader -am -DskipTests`
  2. Run MongoDB reader job with wildcard collection expression.
  3. Verify tasks are created for existing collections only.
  4. Verify query-filtered reads proceed with stable split behavior.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Checklist for maintainers / reviewers (recommended)
- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [ ] Evaluate whether the change requires a migration note.

## Release notes
MongoDB reader now handles wildcard collection split planning more efficiently under query filters, with sequential cursor fallback to avoid skip-based overhead.

## Breaking changes / Migration
None.

## Security
No security-sensitive changes.

## Additional context
N/A

