### PR TITLE
fix(doriswriter): await async Stream Load in post(), not destroy()

### DIFF
--- a/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisWriter.java
+++ b/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisWriter.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
+import static com.wgzhao.addax.core.spi.ErrorCode.EXECUTE_FAIL;
 
 /**
  * doris data writer
@@ -147,9 +148,37 @@ public class DorisWriter
         }
 
         @Override
+        public void post()
+        {
+            try {
+                // flush remaining buffered records and wait for all in-flight
+                // async Stream Load batches to finish before the task is
+                // considered successful.  Doing this in destroy() (as the
+                // original implementation did) lets Addax report SUCCESS
+                // before partial async batches complete, which causes
+                // silent data loss.  This matches the behavior of
+                // DataX DorisWriter, DataX StarRocksWriter and
+                // Addax StarRocksWriter.
+                writerManager.close();
+            }
+            catch (Exception e) {
+                throw AddaxException.asAddaxException(EXECUTE_FAIL, e);
+            }
+        }
+
+        @Override
         public void destroy()
         {
-            writerManager.close();
+            // no-op: writerManager.close() is invoked from post() so that
+            // all async Stream Load batches are awaited before the task
+            // is marked successful.  close() is idempotent, so calling
+            // it again here is safe but unnecessary.
+        }
+
+        @Override
+        public boolean supportFailOver()
+        {
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix silent partial data loss in `doriswriter` by moving the asynchronous  
`Stream Load` batch await from `Task.destroy()` to `Task.post()`, matching the  
behavior of `DataX DorisWriter`, `DataX StarRocksWriter` and  
`Addax StarRocksWriter`.

## Related Issue(s)

Fixes the long-standing partial-data-loss issue described in  
<https://github.com/wgzhao/addax/issues> (the doriswriter lifecycle mismatch).

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- `plugin/writer/doriswriter/.../DorisWriter.java`
  - Added `Task.post()` that calls `writerManager.close()` inside a  
    `try`/`catch` (rethrows as `AddaxException` with `EXECUTE_FAIL`).
  - `Task.destroy()` is now a documented no-op (previously it called  
    `writerManager.close()` *after* the framework had already reported the  
    task as successful).
  - Added explicit `supportFailOver()` returning `false`, matching the  
    `starrockswriter` behavior (avoid accidental failover while an async  
    Stream Load batch is still in flight).
  - Added `import static ... ErrorCode.EXECUTE_FAIL`.

Only one file changed, +30 / -1.

## Motivation and Context

`DorisWriterManager` flushes records to Doris via **asynchronous** `Stream Load`  
batches. The close path (`writerManager.close()`) calls `flush(label, true)`,  
which is the only place that **blocks until all in-flight async batches  
complete** (via `waitAsyncFlushingDone()`).

In Addax 6.0.11 (and earlier), `DorisWriter.Task.destroy()` was the only place  
that invoked `close()`. But `Task.destroy()` runs **after** the framework has  
already reported the task as successful — any async batches that were still  
in flight at that point were abandoned, causing silent partial data loss.

The other three "Stream Load" writers in this codebase (`DataX DorisWriter`,  
`DataX StarRocksWriter`, `Addax StarRocksWriter`) all invoke `close()` from  
`Task.post()`, which runs **before** the task is marked successful. This PR  
aligns Addax doriswriter with that pattern.

## How has this been tested?

- Manual verification:
  1. Built `plugin/writer/doriswriter` with JDK 17 + Maven:  
     `mvn -pl plugin/writer/doriswriter -am compile -DskipTests` (BUILD SUCCESS).
  2. Inspected `DorisWriterManager.close()` to confirm the existing  
     `closed` flag makes it idempotent — so leaving `destroy()` empty  
     (instead of double-calling `close()`) is safe even if the framework  
     invokes both lifecycle hooks.
  3. Confirmed `Task.destroy()` no longer performs any work; the only  
     call site for `writerManager.close()` is `Task.post()`.
- Automated tests: **not added.** This is the first test that would exist  
  in the entire `addax` repo (verified with `find . -name "*Test.java"`,  
  zero results). A meaningful unit test for this lifecycle change would  
  require either (a) a mock Doris FE/BE cluster, or (b) significant new  
  test infrastructure (JUnit 5 + surefire wiring + mocking). Both are  
  out of scope for a one-line behavior fix. Happy to add one in a  
  follow-up PR if the maintainer wants it.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable). — *see note in "How has this been tested?"*
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed — *not needed; no public API change.*
- [ ] I updated CHANGELOG.md when appropriate — *not used by this project.*
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Checklist for maintainers / reviewers (recommended)

- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [ ] Evaluate whether the change requires a migration note.

## Release notes

`doriswriter` no longer reports a task as successful while asynchronous  
Stream Load batches are still in flight. This eliminates a long-running  
cause of silent partial data loss when loading large datasets into Doris.  
No configuration or API changes are required.

## Breaking changes / Migration

None. The fix only changes **when** `writerManager.close()` is invoked  
inside the task lifecycle, not its semantics, not its arguments, and not  
its idempotency. Existing job configurations are unaffected.

## Security

N/A.

## Additional context

Diff (single file, +30 / -1):

```diff
diff --git a/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisWriter.java
@@
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
+import static com.wgzhao.addax.core.spi.ErrorCode.EXECUTE_FAIL;
@@
+        @Override
+        public void post()
+        {
+            try {
+                writerManager.close();
+            }
+            catch (Exception e) {
+                throw AddaxException.asAddaxException(EXECUTE_FAIL, e);
+            }
+        }
+
         @Override
         public void destroy()
         {
-            writerManager.close();
+            // no-op: see post()
         }
+
+        @Override
+        public boolean supportFailOver()
+        {
+            return false;
+        }
```
