### PR TITLE
fix(mongodbwriter): support authDb parameter for MongoDB authentication

### DIFF
--- a/plugin/writer/mongodbwriter/src/main/java/com/wgzhao/addax/plugin/writer/mongodbwriter/MongoDBWriter.java
+++ b/plugin/writer/mongodbwriter/src/main/java/com/wgzhao/addax/plugin/writer/mongodbwriter/MongoDBWriter.java
@@ -101,6 +101,7 @@ public class MongoDBWriter
 
             String dbName = connConf.getNecessaryValue(DATABASE, REQUIRED_VALUE);
             String collection = connConf.getNecessaryValue(KeyConstant.MONGO_COLLECTION_NAME, REQUIRED_VALUE);
+            String authDb = connConf.getString("authDb", dbName);
             String username = connConf.getString(USERNAME);
             String password = connConf.getString(PASSWORD);
             if (password != null && password.startsWith(Constant.ENC_PASSWORD_PREFIX)) {
@@ -112,7 +113,7 @@ public class MongoDBWriter
                 mongoClient = MongoUtil.initMongoClient(address);
             }
             else {
-                mongoClient = MongoUtil.initCredentialMongoClient(address, username, password, dbName);
+                mongoClient = MongoUtil.initCredentialMongoClient(address, username, password, authDb);
             }
 
             String preSqls = connConf.getString(PRE_SQL);
@@ -190,9 +191,10 @@ public class MongoDBWriter
             }
             Configuration connConf = writerSliceConfig.getConfiguration(CONNECTION);
             this.database = connConf.getString(DATABASE);
+            String authDb = connConf.getString("authDb", this.database);
             List<Object> addressList = connConf.getList(KeyConstant.MONGO_ADDRESS, Object.class);
             this.mongoClient = StringUtils.isNotEmpty(userName) && StringUtils.isNotEmpty(password) ?
-                    MongoUtil.initCredentialMongoClient(addressList, userName, password, database) :
+                    MongoUtil.initCredentialMongoClient(addressList, userName, password, authDb) :
                     MongoUtil.initMongoClient(addressList);
 
             this.collection = connConf.getString(KeyConstant.MONGO_COLLECTION_NAME);


### PR DESCRIPTION
## 问题描述

mongodbwriter 插件忽略了 connection 配置中的 `authDb` 字段，始终使用 `database` 作为 MongoDB 认证源（authSource）。

当 MongoDB 用户创建在 `admin` 数据库（而非业务数据库）时，认证会失败：

```
MongoCommandException: Command failed with error 18 (AuthenticationFailed)
```

## 复现步骤

配置中指定 `authDb: "admin"`，但 `database` 为业务库：

```json
"connection": {
    "address": ["host:27017"],
    "database": "mydb",
    "collection": "mycollection",
    "authDb": "admin"
}
```

实际认证时使用了 `mydb` 作为 authSource，导致 AuthenticationFailed。

## 根因

`MongoDBWriter.java` 中 `Job.prepare()` 和 `Task.init()` 两处调用 `MongoUtil.initCredentialMongoClient()` 时，直接传入 `database`（连接数据库名），未读取 `authDb` 配置项。

## 修复内容

- 从 connection 配置中读取可选的 `authDb` 字段
- 未配置时默认使用 `database` 值，保持向后兼容
- 修复了 `Job.prepare()` 和 `Task.init()` 两处调用