### PR TITLE
feat(addax-gen): generate runnable jobs from connection strings

### DIFF
--- a/core/src/main/bin/addax.sh
+++ b/core/src/main/bin/addax.sh
@@ -307,6 +307,33 @@ list_all_plugin_names() {
 
 if [ "$1" = "gen" ]; then
     shift 1
+    # connection-string based generation when any argument carries scheme://...,
+    # otherwise legacy template stitching
+    case "$*" in
+        *://*)
+            check_jdk_version
+            # add only the reader/writer plugin dirs of the two connection strings to the
+            # classpath (JDBC drivers live there, not in lib/). Adding every plugin would
+            # make DriverManager scan unrelated drivers (e.g. Ucanaccess) and fail.
+            GEN_CP="${CLASS_PATH}"
+            for arg in "$@"; do
+                case "$arg" in
+                    --to=*://*) conn=${arg#--to=} ;;
+                    *://*) conn=${arg} ;;
+                    *) continue ;;
+                esac
+                scheme=${conn%%://*}
+                # hdfs is a generation-only endpoint; no JDBC driver to load
+                [ "$scheme" = "hdfs" ] && continue
+                for plug in "reader/${scheme}reader" "writer/${scheme}writer"; do
+                    for j in "${ADDAX_HOME}/plugin/${plug}/"*.jar "${ADDAX_HOME}/plugin/${plug}/libs/"*.jar; do
+                        [ -f "$j" ] && GEN_CP="${GEN_CP}:${j}"
+                    done
+                done
+            done
+            exec java -server ${DEFAULT_JVM} -classpath "${GEN_CP}" ${DEFAULT_PROPERTY_CONF} com.wgzhao.addax.gen.AddaxGen "$@"
+            ;;
+    esac
     generate_json "$@"
     exit 0
 fi

--- a/lib/addax-gen/package.xml
+++ b/lib/addax-gen/package.xml
@@ -1,0 +1,45 @@
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<assembly
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-component-1.1.2.xsd">
+    <id>release</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target/</directory>
+            <includes>
+                <include>${project.artifactId}-${project.version}.jar</include>
+            </includes>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/lib/addax-gen/pom.xml
+++ b/lib/addax-gen/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.wgzhao.addax</groupId>
+        <artifactId>addax-all</artifactId>
+        <version>6.0.13-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>addax-gen</artifactId>
+    <name>addax-gen</name>
+    <description>Job configuration generator for Addax</description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.wgzhao.addax</groupId>
+            <artifactId>addax-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.wgzhao.addax</groupId>
+            <artifactId>addax-rdbms</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/AddaxGen.java
+++ b/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/AddaxGen.java
@@ -1,0 +1,624 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.gen;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import com.wgzhao.addax.core.exception.AddaxException;
+import com.wgzhao.addax.core.util.EncryptUtil;
+import com.wgzhao.addax.rdbms.util.SchemaProbe;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static com.wgzhao.addax.core.base.Constant.ENC_PASSWORD_PREFIX;
+import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
+import static com.wgzhao.addax.core.spi.ErrorCode.IO_ERROR;
+
+/**
+ * Main entry for the {@code addax gen} command.
+ * <p>
+ * Supported scenarios:
+ * <ul>
+ *   <li>RDBMS to RDBMS: two JDBC connection strings, both sides probed and filled</li>
+ *   <li>RDBMS to HDFS: a JDBC source and an {@code hdfs://host:port/path} target
+ *       that fills the hdfswriter template (defaultFS, path, typed columns, and
+ *       optional fileType/writeMode/compress/kerberos/hadoopConfig overrides)</li>
+ * </ul>
+ * Anything else is rejected with a pointer to the legacy {@code gen -r/-w}
+ * template stitching.
+ */
+public class AddaxGen
+{
+    private static final String USAGE = """
+            Usage: addax gen [options] <source-connection-string> --to <target>
+              --to <connection-string>   target JDBC connection string, or hdfs://host:port/path (required)
+              --table <table>            table name, once per side (default: same table)
+              --columns a,b,c            explicit column list (default: all probed columns)
+              --channel N                parallel channels (default: 1)
+              --password-env VAR         read source password from environment variable
+              --output <file>            write job to file instead of stdout
+              --overwrite                allow overwriting an existing output file
+              --no-probe                 skip schema probing, emit template skeleton
+              -l                         list all reader/writer plugin names
+            HDFS target options (only with --to hdfs://...):
+              --file-type orc|parquet|text   output file type (default: orc)
+              --write-mode append|overwrite|nonConflict (default: overwrite)
+              --compress NONE|GZIP|SNAPPY|LZO|BZIP2 (default: SNAPPY)
+              --field-delimiter <char>       text file delimiter (default: template default)
+              --encoding <charset>           text file encoding
+              --file-name <name>             output file name (default: source table name)
+              --have-kerberos true|false     enable kerberos (default: false)
+              --kerberos-principal <p>       kerberos principal (with --have-kerberos true)
+              --kerberos-keytab <path>       kerberos keytab path (with --have-kerberos true)
+              --hadoop-config k=v           extra hadoop config entry (repeatable, e.g. HA nameservices)
+              --hdfs-site-path <path>       path to hdfs-site.xml (alternative to --hadoop-config)
+            Connection string: scheme://user:password@host:port/database
+            """;
+
+    private String sourcePasswordEnv;
+    private boolean overwrite;
+    private boolean noProbe;
+    private String outputFile;
+    private int channel = 1;
+    private List<String> explicitColumns;
+    private final List<String> tables = new ArrayList<>();
+
+    // HDFS target options
+    private String fileType;
+    private String writeMode;
+    private String compress;
+    private String fieldDelimiter;
+    private String encoding;
+    private String fileName;
+    private boolean haveKerberos;
+    private String kerberosPrincipal;
+    private String kerberosKeytab;
+    private final List<String> hadoopConfigs = new ArrayList<>();
+    private String hdfsSitePath;
+
+    public static void main(String[] args)
+    {
+        int code = new AddaxGen().run(args);
+        System.exit(code);
+    }
+
+    private int run(String[] args)
+    {
+        List<String> positional = new ArrayList<>();
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            switch (arg) {
+                case "--to" -> positional.add("--to=" + requireValue(args, ++i, arg));
+                case "--table" -> tables.add(requireValue(args, ++i, arg));
+                case "--columns" -> explicitColumns = Arrays.asList(requireValue(args, ++i, arg).split(","));
+                case "--channel" -> channel = parseInt(args, ++i);
+                case "--password-env" -> sourcePasswordEnv = requireValue(args, ++i, arg);
+                case "--output" -> outputFile = requireValue(args, ++i, arg);
+                case "--overwrite" -> overwrite = true;
+                case "--no-probe" -> noProbe = true;
+                case "--file-type" -> fileType = requireValue(args, ++i, arg);
+                case "--write-mode" -> writeMode = requireValue(args, ++i, arg);
+                case "--compress" -> compress = requireValue(args, ++i, arg);
+                case "--field-delimiter" -> fieldDelimiter = requireValue(args, ++i, arg);
+                case "--encoding" -> encoding = requireValue(args, ++i, arg);
+                case "--file-name" -> fileName = requireValue(args, ++i, arg);
+                case "--have-kerberos" -> haveKerberos = Boolean.parseBoolean(requireValue(args, ++i, arg));
+                case "--kerberos-principal" -> kerberosPrincipal = requireValue(args, ++i, arg);
+                case "--kerberos-keytab" -> kerberosKeytab = requireValue(args, ++i, arg);
+                case "--hadoop-config" -> hadoopConfigs.add(requireValue(args, ++i, arg));
+                case "--hdfs-site-path" -> hdfsSitePath = requireValue(args, ++i, arg);
+                case "-l" -> {
+                    listPlugins();
+                    return 0;
+                }
+                case "-h", "--help" -> {
+                    System.out.println(USAGE);
+                    return 0;
+                }
+                default -> {
+                    if (arg.startsWith("-")) {
+                        System.err.println("Unknown option: " + arg);
+                        System.err.println(USAGE);
+                        return 2;
+                    }
+                    positional.add(arg);
+                }
+            }
+        }
+
+        if (positional.isEmpty()) {
+            System.err.println("Missing source connection string");
+            System.err.println(USAGE);
+            return 2;
+        }
+        if (!positional.stream().anyMatch(p -> p.startsWith("--to="))) {
+            System.err.println("Missing --to target connection string");
+            System.err.println(USAGE);
+            return 2;
+        }
+
+        String sourceConn = positional.get(0);
+        String targetConn = positional.stream().filter(p -> p.startsWith("--to=")).findFirst()
+                .orElseThrow().substring("--to=".length());
+        String sourceTable = tables.isEmpty() ? "" : tables.get(0);
+        String targetTable = tables.size() > 1 ? tables.get(1) : sourceTable;
+        if (sourceTable.isEmpty()) {
+            System.err.println("Missing --table");
+            System.err.println(USAGE);
+            return 2;
+        }
+
+        try {
+            generate(sourceConn, targetConn, sourceTable, targetTable);
+            return 0;
+        }
+        catch (AddaxException e) {
+            System.err.println("Error: " + e.getMessage());
+            if (e.getCause() != null) {
+                System.err.println("Caused by: " + e.getCause().getMessage());
+            }
+            return 1;
+        }
+        catch (IllegalArgumentException e) {
+            System.err.println("Error: " + e.getMessage());
+            return 2;
+        }
+    }
+
+    private void generate(String sourceConnString, String targetConnString, String sourceTable, String targetTable)
+    {
+        // the source must be a JDBC connection string (RDBMS)
+        if (!sourceConnString.contains("://")) {
+            System.err.println("Error: the source must be a JDBC connection string (scheme://...)."
+                    + " Only RDBMS-to-RDBMS and RDBMS-to-HDFS generation is supported;"
+                    + " for other plugins use 'addax.sh gen -r <reader> -w <writer>'");
+            return;
+        }
+        if (!isHdfsTarget(targetConnString) && !targetConnString.contains("://")) {
+            System.err.println("Error: unsupported target '" + targetConnString + "'. Only RDBMS-to-RDBMS"
+                    + " and RDBMS-to-HDFS generation is supported; for other plugins use"
+                    + " 'addax.sh gen -r <reader> -w <writer>'");
+            return;
+        }
+        ConnectionString source = ConnectionString.parse(sourceConnString);
+
+        Path addaxHome = Path.of(System.getProperty("addax.home", "."));
+        JSONObject readerTemplate = readTemplate(addaxHome, "reader", source.readerPlugin());
+        JSONObject writerTemplate = isHdfsTarget(targetConnString)
+                ? readTemplate(addaxHome, "writer", "hdfswriter")
+                : readTemplate(addaxHome, "writer", ConnectionString.parse(targetConnString).writerPlugin());
+
+        if (noProbe) {
+            emit(readerTemplate, writerTemplate);
+            return;
+        }
+
+        String sourcePassword = sourcePassword();
+        if (sourcePassword == null) {
+            sourcePassword = source.password();
+        }
+
+        // probe the source schema
+        List<SchemaProbe.ColumnInfo> probedColumns = SchemaProbe.getColumns(
+                source.dataBaseType(), source.toJdbcUrl(), source.username(), sourcePassword,
+                source.database(), sourceTable);
+        if (probedColumns.isEmpty()) {
+            System.err.println("Error: source table '" + sourceTable + "' not found or has no columns");
+            return;
+        }
+        List<String> sourceNames = probedColumns.stream().map(c -> c.name).toList();
+        List<String> selectedColumns = explicitColumns == null ? sourceNames : validateColumns(sourceNames, explicitColumns);
+
+        String splitPk = null;
+        if (isHdfsTarget(targetConnString)) {
+            fillHdfsWriter(writerTemplate, targetConnString, sourceTable, probedColumns, selectedColumns);
+        }
+        else {
+            ConnectionString target = ConnectionString.parse(targetConnString);
+            // verify the target table and warn about mismatches
+            List<String> targetTables = SchemaProbe.listTables(
+                    target.dataBaseType(), target.toJdbcUrl(), target.username(), target.password(),
+                    target.database());
+            if (!targetTables.contains(targetTable)) {
+                System.err.println("Error: target table '" + targetTable + "' does not exist");
+                suggestSimilar(targetTables, targetTable);
+                return;
+            }
+            List<SchemaProbe.ColumnInfo> targetColumns = SchemaProbe.getColumns(
+                    target.dataBaseType(), target.toJdbcUrl(), target.username(), target.password(),
+                    target.database(), targetTable);
+            Map<String, String> targetTypes = SchemaProbe.columnTypes(targetColumns);
+            warnMissingColumns(selectedColumns, targetTypes);
+            warnTypeMismatches(probedColumns, targetTypes);
+
+            // primary key for splitPk when parallelism > 1
+            if (channel > 1) {
+                List<String> pk = SchemaProbe.getPrimaryKeys(
+                        source.dataBaseType(), source.toJdbcUrl(), source.username(), sourcePassword,
+                        source.database(), sourceTable);
+                if (!pk.isEmpty()) {
+                    splitPk = pk.get(0);
+                }
+            }
+
+            applyToTemplate(writerTemplate, target, targetTable, selectedColumns, null, target.password());
+        }
+
+        applyToTemplate(readerTemplate, source, sourceTable, selectedColumns, splitPk, sourcePassword);
+
+        emit(readerTemplate, writerTemplate);
+    }
+
+    private boolean isHdfsTarget(String target)
+    {
+        return target.startsWith("hdfs://");
+    }
+
+    /**
+     * Fills the hdfswriter template from an {@code hdfs://host:port/path} target and the
+     * probed source columns. Template sample values that only apply to specific setups
+     * (kerberos, HA hadoopConfig, bloom filters) are removed unless explicitly requested.
+     */
+    private void fillHdfsWriter(JSONObject template, String hdfsTarget, String sourceTable,
+            List<SchemaProbe.ColumnInfo> probedColumns, List<String> selectedColumns)
+    {
+        String rest = hdfsTarget.substring("hdfs://".length());
+        int slash = rest.indexOf('/');
+        if (slash <= 0 || slash == rest.length() - 1) {
+            throw AddaxException.asAddaxException(CONFIG_ERROR,
+                    "Invalid HDFS target (expected hdfs://host:port/path): " + hdfsTarget);
+        }
+        String defaultFS = "hdfs://" + rest.substring(0, slash);
+        // keep the leading slash: hdfs://host/tmp yields the absolute path /tmp
+        String path = rest.substring(slash);
+
+        JSONObject parameter = template.getJSONObject("parameter");
+        parameter.put("defaultFS", defaultFS);
+        parameter.put("path", path);
+        parameter.put("fileName", fileName != null ? fileName : sourceTable);
+        if (fileType != null) {
+            parameter.put("fileType", fileType);
+        }
+        if (writeMode != null) {
+            parameter.put("writeMode", writeMode);
+        }
+        if (compress != null) {
+            parameter.put("compress", compress);
+        }
+        if (fieldDelimiter != null) {
+            parameter.put("fieldDelimiter", fieldDelimiter);
+        }
+        if (encoding != null) {
+            parameter.put("encoding", encoding);
+        }
+
+        // typed column list generated from the source schema
+        JSONArray columnEntries = new JSONArray();
+        for (SchemaProbe.ColumnInfo column : probedColumns) {
+            if (!selectedColumns.contains(column.name)) {
+                continue;
+            }
+            JSONObject entry = new JSONObject();
+            entry.put("name", column.name);
+            entry.put("type", mapColumnType(column.typeName));
+            columnEntries.add(entry);
+        }
+        parameter.put("column", columnEntries);
+
+        // kerberos defaults to off; the template's sample values are removed
+        parameter.put("haveKerberos", Boolean.toString(haveKerberos));
+        if (haveKerberos) {
+            parameter.put("kerberosPrincipal", kerberosPrincipal != null ? kerberosPrincipal : "");
+            parameter.put("kerberosKeytabFilePath", kerberosKeytab != null ? kerberosKeytab : "");
+        }
+        else {
+            parameter.remove("kerberosPrincipal");
+            parameter.remove("kerberosKeytabFilePath");
+        }
+
+        // HA configuration only when explicitly provided; otherwise drop the sample block
+        if (!hadoopConfigs.isEmpty()) {
+            JSONObject config = new JSONObject();
+            for (String entry : hadoopConfigs) {
+                int eq = entry.indexOf('=');
+                if (eq <= 0) {
+                    throw AddaxException.asAddaxException(CONFIG_ERROR,
+                            "Invalid --hadoop-config entry (expected k=v): " + entry);
+                }
+                config.put(entry.substring(0, eq), entry.substring(eq + 1));
+            }
+            parameter.put("hadoopConfig", config);
+        }
+        else {
+            parameter.remove("hadoopConfig");
+        }
+
+        // hdfs-site.xml path as an alternative to manual hadoopConfig entries
+        if (hdfsSitePath != null) {
+            parameter.put("hdfsSitePath", hdfsSitePath);
+        }
+
+        // bloom filters are not generated in v1; drop the template's sample columns
+        parameter.remove("bloom.filter.columns");
+        parameter.remove("bloom.filter.fpp");
+    }
+
+    /** Fills connection, credentials, columns and splitPk into a JDBC plugin template. */
+    private void applyToTemplate(JSONObject template, ConnectionString conn, String table,
+            List<String> columns, String splitPk, String password)
+    {
+        JSONObject parameter = template.getJSONObject("parameter");
+        JSONObject connection = parameter.getJSONObject("connection");
+        if (connection == null) {
+            // some templates declare connection as an array of one object
+            JSONArray connections = parameter.getJSONArray("connection");
+            if (connections != null && !connections.isEmpty()) {
+                connection = connections.getJSONObject(0);
+            }
+        }
+        if (connection != null) {
+            connection.put("jdbcUrl", conn.toJdbcUrl());
+            connection.put("table", Collections.singletonList(table));
+        }
+        if (conn.username() != null) {
+            parameter.put("username", conn.username());
+        }
+        parameter.put("password", encrypt(password != null ? password : ""));
+        parameter.put("column", columns);
+        if (splitPk != null && parameter.containsKey("splitPk")) {
+            parameter.put("splitPk", splitPk);
+        }
+    }
+
+    /**
+     * Maps a JDBC type name to the Hive type string used in the hdfswriter column config
+     * (SupportHiveDataType). Integer types are matched by exact name, because substring
+     * matching would misclassify types like PostgreSQL 'interval' or 'point' as integers.
+     * Hive has no TIME or INTERVAL type, so those fall back to STRING with a warning.
+     */
+    private String mapColumnType(String jdbcTypeName)
+    {
+        if (jdbcTypeName == null) {
+            return "string";
+        }
+        String type = jdbcTypeName.toLowerCase(Locale.ROOT);
+        if (type.contains("bool")) {
+            return "boolean";
+        }
+        if (type.equals("tinyint")) {
+            return "tinyint";
+        }
+        if (type.equals("smallint") || type.equals("int2")) {
+            return "smallint";
+        }
+        if (type.equals("bigint") || type.equals("int8") || type.equals("serial8")) {
+            return "bigint";
+        }
+        if (type.equals("int") || type.equals("int4") || type.equals("integer")
+                || type.equals("mediumint") || type.equals("serial") || type.equals("serial4")) {
+            return "int";
+        }
+        if (type.contains("char") || type.contains("text") || type.contains("uuid")
+                || type.contains("json") || type.contains("bytea")) {
+            return "string";
+        }
+        if (type.contains("double") || type.contains("float") || type.contains("real")
+                || type.contains("money")) {
+            return "double";
+        }
+        if (type.contains("decimal") || type.contains("numeric")) {
+            return "decimal";
+        }
+        if (type.contains("timestamp")) {
+            return "timestamp";
+        }
+        if (type.equals("date")) {
+            return "date";
+        }
+        if (type.equals("time") || type.equals("timetz")) {
+            System.err.println("Warning: column type '" + jdbcTypeName + "' has no Hive equivalent, mapped to string");
+            return "string";
+        }
+        if (type.equals("interval")) {
+            System.err.println("Warning: column type 'interval' has no Hive equivalent, mapped to string");
+            return "string";
+        }
+        System.err.println("Warning: unmapped column type '" + jdbcTypeName + "' falls back to string");
+        return "string";
+    }
+
+    private void emit(JSONObject readerTemplate, JSONObject writerTemplate)
+    {
+        JSONObject job = new JSONObject();
+        JSONObject setting = new JSONObject();
+        JSONObject speed = new JSONObject();
+        speed.put("byte", -1);
+        speed.put("channel", channel);
+        setting.put("speed", speed);
+        JSONObject content = new JSONObject();
+        content.put("reader", readerTemplate);
+        content.put("writer", writerTemplate);
+        job.put("setting", setting);
+        job.put("content", content);
+
+        String json = JSON.toJSONString(new JSONObject().fluentPut("job", job), JSONWriter.Feature.PrettyFormat);
+        if (outputFile == null) {
+            System.out.println(json);
+            System.out.flush();
+        }
+        else {
+            writeFile(Path.of(outputFile), json);
+        }
+    }
+
+    private void writeFile(Path path, String content)
+    {
+        try {
+            if (Files.exists(path) && !overwrite) {
+                System.err.println("Error: output file already exists: " + path + " (use --overwrite to replace)");
+                return;
+            }
+            Files.writeString(path, content, StandardCharsets.UTF_8);
+            // the file contains credentials, so restrict access to the owner
+            if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Set<PosixFilePermission> perms = Set.of(
+                        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+                Files.setPosixFilePermissions(path, perms);
+            }
+            System.err.println("Job written to " + path);
+        }
+        catch (IOException e) {
+            throw AddaxException.asAddaxException(IO_ERROR, "Failed to write output file " + path, e);
+        }
+    }
+
+    private JSONObject readTemplate(Path addaxHome, String type, String plugin)
+    {
+        Path template = addaxHome.resolve("plugin").resolve(type).resolve(plugin).resolve("plugin_job_template.json");
+        if (!Files.exists(template)) {
+            throw AddaxException.asAddaxException(CONFIG_ERROR, "Plugin " + plugin + " is not installed (missing " + template + ")");
+        }
+        try {
+            return JSON.parseObject(Files.readString(template, StandardCharsets.UTF_8));
+        }
+        catch (IOException e) {
+            throw AddaxException.asAddaxException(IO_ERROR, "Failed to read template " + template, e);
+        }
+    }
+
+    private List<String> validateColumns(List<String> sourceNames, List<String> requested)
+    {
+        List<String> lower = sourceNames.stream().map(s -> s.toLowerCase(Locale.ROOT)).toList();
+        for (String col : requested) {
+            if (!lower.contains(col.toLowerCase(Locale.ROOT))) {
+                System.err.println("Warning: column '" + col + "' not found in source table");
+            }
+        }
+        return requested;
+    }
+
+    private void warnMissingColumns(List<String> selected, Map<String, String> targetTypes)
+    {
+        for (String column : selected) {
+            if (!targetTypes.containsKey(column.toLowerCase(Locale.ROOT))) {
+                System.err.println("Warning: column '" + column + "' does not exist in the target table");
+            }
+        }
+    }
+
+    private void warnTypeMismatches(List<SchemaProbe.ColumnInfo> sourceColumns, Map<String, String> targetTypes)
+    {
+        for (SchemaProbe.ColumnInfo column : sourceColumns) {
+            String targetType = targetTypes.get(column.name.toLowerCase(Locale.ROOT));
+            if (targetType != null && !targetType.equalsIgnoreCase(column.typeName)) {
+                System.err.println("Warning: type mismatch for column '" + column.name
+                        + "': source " + column.typeName + " -> target " + targetType);
+            }
+        }
+    }
+
+    private void suggestSimilar(List<String> tables, String wanted)
+    {
+        String lower = wanted.toLowerCase(Locale.ROOT);
+        List<String> similar = tables.stream()
+                .filter(t -> t.toLowerCase(Locale.ROOT).contains(lower) || lower.contains(t.toLowerCase(Locale.ROOT)))
+                .limit(5)
+                .toList();
+        if (!similar.isEmpty()) {
+            System.err.println("Did you mean: " + String.join(", ", similar));
+        }
+    }
+
+    private void listPlugins()
+    {
+        Path addaxHome = Path.of(System.getProperty("addax.home", "."));
+        System.out.println("Reader Plugins:");
+        listDir(addaxHome.resolve("plugin/reader"));
+        System.out.println();
+        System.out.println("Writer Plugins:");
+        listDir(addaxHome.resolve("plugin/writer"));
+    }
+
+    private void listDir(Path dir)
+    {
+        File[] entries = dir.toFile().listFiles();
+        if (entries == null) {
+            return;
+        }
+        Arrays.stream(entries).filter(File::isDirectory)
+                .map(File::getName)
+                .sorted()
+                .forEach(name -> System.out.println("  " + name));
+    }
+
+    private String sourcePassword()
+    {
+        if (sourcePasswordEnv != null) {
+            String fromEnv = System.getenv(sourcePasswordEnv);
+            if (fromEnv == null) {
+                throw AddaxException.asAddaxException(CONFIG_ERROR,
+                        "Environment variable " + sourcePasswordEnv + " is not set");
+            }
+            return fromEnv;
+        }
+        return null;
+    }
+
+    /** Encrypts the password in the ${enc:...} form so no plaintext lands in the job file. */
+    private String encrypt(String password)
+    {
+        if (password.isEmpty()) {
+            return password;
+        }
+        return ENC_PASSWORD_PREFIX + EncryptUtil.encrypt(password) + "}";
+    }
+
+    private String requireValue(String[] args, int index, String option)
+    {
+        if (index >= args.length || args[index].startsWith("-")) {
+            throw new IllegalArgumentException("Missing value for " + option);
+        }
+        return args[index];
+    }
+
+    private int parseInt(String[] args, int index)
+    {
+        try {
+            return Integer.parseInt(requireValue(args, index, "--channel"));
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid --channel value: " + args[index]);
+        }
+    }
+}

--- a/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/ConnectionString.java
+++ b/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/ConnectionString.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.gen;
+
+import com.wgzhao.addax.core.exception.AddaxException;
+import com.wgzhao.addax.rdbms.util.DataBaseType;
+
+import java.util.Map;
+
+import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
+
+/**
+ * Parses the user-friendly connection string used by the addax gen command:
+ * <pre>
+ *   scheme://user:password@host:port/database
+ * </pre>
+ * and converts it into a JDBC URL via the scheme table below.
+ * <p>
+ * The scheme is the standard JDBC URL name (mysql, postgresql, oracle, ...),
+ * mapped to the matching {@link DataBaseType} and the dedicated reader/writer
+ * plugin pair. Schemes without a dedicated plugin (db2, trino, hive, ...) are
+ * deliberately unsupported in v1 because they go through the generic
+ * rdbmsreader/rdbmswriter with a jdbcType parameter.
+ */
+public class ConnectionString
+{
+    /** Scheme metadata: default port, JDBC URL template and plugin names. */
+    private static final class Scheme
+    {
+        final DataBaseType dataBaseType;
+        final int defaultPort;
+        final String urlTemplate;
+        final String readerPlugin;
+        final String writerPlugin;
+
+        Scheme(DataBaseType dataBaseType, int defaultPort, String urlTemplate, String readerPlugin, String writerPlugin)
+        {
+            this.dataBaseType = dataBaseType;
+            this.defaultPort = defaultPort;
+            this.urlTemplate = urlTemplate;
+            this.readerPlugin = readerPlugin;
+            this.writerPlugin = writerPlugin;
+        }
+    }
+
+    private static final Map<String, Scheme> SCHEMES = Map.ofEntries(
+            Map.entry("mysql", new Scheme(DataBaseType.MySql, 3306,
+                    "jdbc:mysql://{host}:{port}/{db}?useUnicode=true&characterEncoding=utf-8",
+                    "mysqlreader", "mysqlwriter")),
+            Map.entry("postgresql", new Scheme(DataBaseType.PostgreSQL, 5432,
+                    "jdbc:postgresql://{host}:{port}/{db}",
+                    "postgresqlreader", "postgresqlwriter")),
+            Map.entry("oracle", new Scheme(DataBaseType.Oracle, 1521,
+                    "jdbc:oracle:thin:@//{host}:{port}/{db}",
+                    "oraclereader", "oraclewriter")),
+            Map.entry("clickhouse", new Scheme(DataBaseType.ClickHouse, 8123,
+                    "jdbc:clickhouse://{host}:{port}/{db}",
+                    "clickhousereader", "clickhousewriter")),
+            Map.entry("sqlserver", new Scheme(DataBaseType.SQLServer, 1433,
+                    "jdbc:sqlserver://{host}:{port};DatabaseName={db}",
+                    "sqlserverreader", "sqlserverwriter")),
+            Map.entry("sybase", new Scheme(DataBaseType.Sybase, 5000,
+                    "jdbc:sybase:Tds:{host}:{port}/{db}",
+                    "sybasereader", "sybasewriter")),
+            Map.entry("hana", new Scheme(DataBaseType.HANA, 30015,
+                    "jdbc:sap://{host}:{port}/?databaseName={db}",
+                    "hanareader", "hanawriter")),
+            Map.entry("sqlite", new Scheme(DataBaseType.SQLite, 0,
+                    "jdbc:sqlite:{db}",
+                    "sqlitereader", "sqlitewriter")),
+            Map.entry("tdengine", new Scheme(DataBaseType.TDengine, 6030,
+                    "jdbc:TAOS-RS://{host}:{port}/{db}",
+                    "tdenginereader", "tdenginewriter")),
+            Map.entry("databend", new Scheme(DataBaseType.Databend, 8000,
+                    "jdbc:databend://{host}:{port}/{db}",
+                    "databendreader", "databendwriter"))
+    );
+
+    private final Scheme scheme;
+    private final String username;
+    private final String password;
+    private final String host;
+    private final int port;
+    private final String database;
+
+    private ConnectionString(Scheme scheme, String username, String password,
+            String host, int port, String database)
+    {
+        this.scheme = scheme;
+        this.username = username;
+        this.password = password;
+        this.host = host;
+        this.port = port;
+        this.database = database;
+    }
+
+    /**
+     * Parses a connection string. Passwords containing '@' or ':' are not
+     * supported inline — use the --password-env option instead.
+     */
+    public static ConnectionString parse(String input)
+    {
+        int schemeEnd = input.indexOf("://");
+        if (schemeEnd <= 0) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    "Invalid connection string (expected scheme://user:pass@host:port/db): " + input);
+        }
+        String schemeName = input.substring(0, schemeEnd).toLowerCase();
+        Scheme scheme = SCHEMES.get(schemeName);
+        if (scheme == null) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    "Unsupported scheme '" + schemeName + "' — supported schemes: " + String.join(", ", SCHEMES.keySet()));
+        }
+
+        String rest = input.substring(schemeEnd + 3);
+        String username = null;
+        String password = null;
+        String hostPart = rest;
+        int atIndex = rest.lastIndexOf('@');
+        if (atIndex >= 0) {
+            String userInfo = rest.substring(0, atIndex);
+            hostPart = rest.substring(atIndex + 1);
+            int colon = userInfo.indexOf(':');
+            if (colon >= 0) {
+                username = userInfo.substring(0, colon);
+                password = userInfo.substring(colon + 1);
+            }
+            else {
+                username = userInfo;
+            }
+        }
+
+        String host;
+        int port;
+        String database;
+        if (schemeName.equals("sqlite")) {
+            // sqlite has no host/port; the path is the database file
+            host = "localhost";
+            port = 0;
+            database = hostPart;
+        }
+        else {
+            int slash = hostPart.indexOf('/');
+            String hostPort = slash >= 0 ? hostPart.substring(0, slash) : hostPart;
+            database = slash >= 0 ? hostPart.substring(slash + 1) : "";
+            if (database.isEmpty()) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE, "Missing database name in connection string: " + input);
+            }
+            int colon = hostPort.indexOf(':');
+            if (colon >= 0) {
+                host = hostPort.substring(0, colon);
+                port = Integer.parseInt(hostPort.substring(colon + 1));
+            }
+            else {
+                host = hostPort;
+                port = scheme.defaultPort;
+            }
+            if (host.isEmpty()) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE, "Missing host in connection string: " + input);
+            }
+        }
+        return new ConnectionString(scheme, username, password, host, port, database);
+    }
+
+    public DataBaseType dataBaseType()
+    {
+        return scheme.dataBaseType;
+    }
+
+    public String username()
+    {
+        return username;
+    }
+
+    public String password()
+    {
+        return password;
+    }
+
+    public String database()
+    {
+        return database;
+    }
+
+    public String readerPlugin()
+    {
+        return scheme.readerPlugin;
+    }
+
+    public String writerPlugin()
+    {
+        return scheme.writerPlugin;
+    }
+
+    public String toJdbcUrl()
+    {
+        return scheme.urlTemplate
+                .replace("{host}", host)
+                .replace("{port}", String.valueOf(port))
+                .replace("{db}", database);
+    }
+
+    @Override
+    public String toString()
+    {
+        return schemeName() + "://" + host + ":" + port + "/" + database;
+    }
+
+    private String schemeName()
+    {
+        return scheme.dataBaseType.getTypeName();
+    }
+}

--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/util/SchemaProbe.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/util/SchemaProbe.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.rdbms.util;
+
+import com.wgzhao.addax.core.exception.AddaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.wgzhao.addax.core.spi.ErrorCode.CONNECT_ERROR;
+
+/**
+ * Schema introspection helpers used by the addax gen command and other tools
+ * that need to discover tables, primary keys and column metadata at runtime.
+ * <p>
+ * All methods take a database name (catalog or schema) that is tried as the
+ * JDBC catalog first and as the schema second, because drivers disagree on
+ * where the database name lives in the metadata model.
+ */
+public class SchemaProbe
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaProbe.class);
+
+    /**
+     * Column metadata gathered from JDBC ResultSetMetaData, plus primary key info.
+     */
+    public static class ColumnInfo
+    {
+        public final String name;
+        public final String typeName;
+        public final int precision;
+        public final int scale;
+        public final boolean primaryKey;
+
+        ColumnInfo(String name, String typeName, int precision, int scale, boolean primaryKey)
+        {
+            this.name = name;
+            this.typeName = typeName;
+            this.precision = precision;
+            this.scale = scale;
+            this.primaryKey = primaryKey;
+        }
+    }
+
+    private SchemaProbe() {}
+
+    /**
+     * Loads the JDBC driver for the given database type so the connection
+     * can be established. The driver jar is expected on the runtime classpath.
+     */
+
+    private static Connection connect(DataBaseType dataBaseType, String jdbcUrl, String username, String password)
+            throws SQLException
+    {
+        return java.sql.DriverManager.getConnection(jdbcUrl, username, password);
+    }
+
+    public static void loadDriver(DataBaseType dataBaseType)
+    {
+        try {
+            Class.forName(dataBaseType.getDriverClassName());
+        }
+        catch (ClassNotFoundException e) {
+            throw AddaxException.asAddaxException(CONNECT_ERROR,
+                    "Driver class not found: " + dataBaseType.getDriverClassName()
+                            + " — the driver jar must be present on the classpath", e);
+        }
+    }
+
+    /**
+     * Lists user tables in the given database. The database name is tried as
+     * the JDBC catalog, then as the schema, then in both positions, then as a
+     * last resort all tables across schemas (system schemas excluded), because
+     * drivers disagree on where the database name lives in the metadata model.
+     */
+    public static List<String> listTables(DataBaseType dataBaseType, String jdbcUrl,
+            String username, String password, String database)
+    {
+        loadDriver(dataBaseType);
+        // plain DriverManager connection instead of DBUtil's DBCP pool, because DBCP
+        // scans every Driver on the classpath and fails on unrelated plugins' drivers
+        try (Connection conn = connect(dataBaseType, jdbcUrl, username, password)) {
+            List<String> tables = listTables(conn, database, database);
+            if (tables.isEmpty()) {
+                tables = listTables(conn, null, database);
+            }
+            if (tables.isEmpty()) {
+                tables = listTables(conn, database, null);
+            }
+            if (tables.isEmpty()) {
+                tables = listTables(conn, null, null);
+            }
+            return tables;
+        }
+        catch (SQLException e) {
+            throw AddaxException.asAddaxException(CONNECT_ERROR, "Failed to list tables", e);
+        }
+    }
+
+    /**
+     * Returns the primary key columns of a table, ordered by KEY_SEQ.
+     */
+    public static List<String> getPrimaryKeys(DataBaseType dataBaseType, String jdbcUrl,
+            String username, String password, String database, String table)
+    {
+        loadDriver(dataBaseType);
+        // plain DriverManager connection instead of DBUtil's DBCP pool, because DBCP
+        // scans every Driver on the classpath and fails on unrelated plugins' drivers
+        try (Connection conn = connect(dataBaseType, jdbcUrl, username, password)) {
+            return getPrimaryKeys(conn, database, table);
+        }
+        catch (SQLException e) {
+            throw AddaxException.asAddaxException(CONNECT_ERROR, "Failed to read primary key of table " + table, e);
+        }
+    }
+
+    /**
+     * Returns column metadata for a table, including primary key flags.
+     */
+    public static List<ColumnInfo> getColumns(DataBaseType dataBaseType, String jdbcUrl,
+            String username, String password, String database, String table)
+    {
+        loadDriver(dataBaseType);
+        // plain DriverManager connection instead of DBUtil's DBCP pool, because DBCP
+        // scans every Driver on the classpath and fails on unrelated plugins' drivers
+        try (Connection conn = connect(dataBaseType, jdbcUrl, username, password)) {
+            return getColumns(conn, database, table);
+        }
+        catch (SQLException e) {
+            throw AddaxException.asAddaxException(CONNECT_ERROR, "Failed to read columns of table " + table, e);
+        }
+    }
+
+    /**
+     * Builds a map of column name to JDBC type name for quick name matching.
+     */
+    public static Map<String, String> columnTypes(List<ColumnInfo> columns)
+    {
+        Map<String, String> result = new HashMap<>();
+        for (ColumnInfo column : columns) {
+            result.put(column.name.toLowerCase(), column.typeName);
+        }
+        return result;
+    }
+
+    private static List<String> listTables(Connection conn, String catalog, String schema)
+            throws SQLException
+    {
+        List<String> tables = new ArrayList<>();
+        DatabaseMetaData metaData = conn.getMetaData();
+        try (ResultSet rs = metaData.getTables(catalog, schema, "%", new String[] {"TABLE"})) {
+            while (rs.next()) {
+                String schemaName = rs.getString("TABLE_SCHEM");
+                // skip system schemas when falling back to a full listing
+                if (schema == null && schemaName != null
+                        && (schemaName.startsWith("pg_") || "information_schema".equals(schemaName))) {
+                    continue;
+                }
+                tables.add(rs.getString("TABLE_NAME"));
+            }
+        }
+        return tables;
+    }
+
+    private static List<String> getPrimaryKeys(Connection conn, String catalog, String table)
+            throws SQLException
+    {
+        // drivers disagree on where the database name lives (catalog vs schema),
+        // so fall back to no catalog when the first attempt returns nothing
+        List<String> keys = readPrimaryKeys(conn, catalog, table);
+        if (keys.isEmpty()) {
+            keys = readPrimaryKeys(conn, null, table);
+        }
+        return keys;
+    }
+
+    private static List<String> readPrimaryKeys(Connection conn, String catalog, String table)
+            throws SQLException
+    {
+        DatabaseMetaData metaData = conn.getMetaData();
+        List<String[]> keys = new ArrayList<>();
+        try (ResultSet rs = metaData.getPrimaryKeys(catalog, null, table)) {
+            while (rs.next()) {
+                keys.add(new String[] {rs.getString("KEY_SEQ"), rs.getString("COLUMN_NAME")});
+            }
+        }
+        keys.sort((a, b) -> Integer.compare(Integer.parseInt(a[0]), Integer.parseInt(b[0])));
+        List<String> result = new ArrayList<>();
+        for (String[] key : keys) {
+            result.add(key[1]);
+        }
+        return result;
+    }
+
+    private static List<ColumnInfo> getColumns(Connection conn, String catalog, String table)
+            throws SQLException
+    {
+        Set<String> pkColumns = new LinkedHashSet<>(getPrimaryKeys(conn, catalog, table));
+        List<Map<String, Object>> meta = DBUtil.getColumnMetaData(conn, table, "*");
+        List<ColumnInfo> columns = new ArrayList<>();
+        // index 0 is a null placeholder kept by getColumnMetaData
+        for (int i = 1; i < meta.size(); i++) {
+            Map<String, Object> row = meta.get(i);
+            columns.add(new ColumnInfo(
+                    (String) row.get("name"),
+                    (String) row.get("typeName"),
+                    (Integer) row.get("precision"),
+                    (Integer) row.get("scale"),
+                    pkColumns.contains(((String) row.get("name")).toLowerCase())));
+        }
+        return columns;
+    }
+}

--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,14 @@
             <outputDirectory>lib</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>lib/addax-gen/target/addax-gen-${project.version}/lib/</directory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+            <fileMode>0644</fileMode>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>lib/addax-rdbms/target/addax-rdbms-${project.version}/lib/</directory>
             <includes>
                 <include>*.*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <modules>
         <!-- common modules -->
         <module>core</module>
+        <module>lib/addax-gen</module>
         <module>lib/addax-rdbms</module>
         <module>lib/addax-storage</module>
         <!-- reader -->


### PR DESCRIPTION
## Summary

Extends `addax.sh gen` from template stitching to **connection-string based automatic job generation**: `addax gen mysql://user:pass@host:3306/ods --table users --to clickhouse://default@host:8123/ods --table users` produces a runnable job JSON with connection info, tables, columns, field mapping and splitPk filled in automatically.

## Related Issue(s)

None (new feature). Design documented in [addax-docs docs/gen.md](https://github.com/wgzhao/addax-docs/blob/master/docs/gen.md).

## What type of change is this?

- [x] New feature

## Changes

- **New module `lib/addax-gen`**: `AddaxGen` (CLI entry) + `ConnectionString` (scheme → `DataBaseType` mapping with default ports and JDBC URL templates, 10 JDBC-based schemes: mysql, postgresql, oracle, clickhouse, sqlserver, sybase, hana, sqlite, tdengine, databend)
- **`lib/addax-rdbms`**: new `SchemaProbe` (listTables / getPrimaryKeys / getColumns) with catalog/schema fallback chains and system-schema filtering; uses plain `DriverManager` connections to avoid DBCP's classpath-wide driver scan
- **`core/src/main/bin/addax.sh`**: `gen` detects a connection string (`://`) and invokes `AddaxGen` with a classpath that includes plugin dirs (where JDBC drivers live); legacy `-r/-w` stitching and `-l` listing remain unchanged
- **Build**: `addax-gen` registered in root pom + `package.xml` (lib collection); module follows the same assembly pattern as `addax-rdbms`

Generated jobs:
- Columns auto-filled from source schema probe (or `--columns`), target columns matched by name
- `splitPk` auto-filled when a primary key is found and `--channel` > 1
- Passwords emitted as `${enc:...}` ciphertext (never plaintext), output file mode 600
- Missing target columns / type mismatches reported as warnings, never silent

## Motivation and Context

The legacy `gen` only concatenates plugin templates, leaving every connection field as a placeholder — authoring a job still means manually editing all connection info, table names and columns. A connection-string based generator with schema probing reduces job authoring from minutes to seconds.

## How has this been tested?

Manually verified end-to-end against a local PostgreSQL:

1. Built the full distribution package: `mvn clean package && mvn package -Pdistribution` (the CI flow)
2. `bin/addax.sh gen postgresql://wgzhao@localhost:5432/postgres --table src_users --to postgresql://wgzhao@localhost:5432/postgres --table dst_users --channel 2 --output /tmp/gen-e2e-job.json`
3. Ran the generated job: `bin/addax.sh /tmp/gen-e2e-job.json` → 2 rows synced, 0 failed, verified via SQL query
4. Error paths verified: missing `--to`, unsupported scheme (e.g. `mongodb://`), missing table
5. Legacy modes verified: `gen -r/-w` template stitching and `gen -l` plugin listing unchanged
6. Full build green: `mvn clean package -T1C -DskipTests` with JDK 17

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable). — no unit tests per project convention; verified manually
- [x] I ran a local build and fixed any compilation issues.
- [x] I updated or added documentation if needed (README, docs/ or docs/en/). — design doc added to addax-docs (docs/gen.md, docs/en/gen.md)
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Release notes

`addax.sh gen` now accepts connection strings (`scheme://user:pass@host:port/db`) and auto-generates runnable job JSON via schema probing; legacy `-r/-w` mode is unchanged.

## Breaking changes / Migration

None. Legacy `gen -r/-w` behavior is fully preserved.

## Additional context

- Scope (per maintainer decision): **RDBMS ↔ RDBMS** (10 connection-string schemes: mysql, postgresql, oracle, clickhouse, sqlserver, sybase, hana, sqlite, tdengine, databend) and **RDBMS → HDFS** (`--to hdfs://host:port/path`; fills defaultFS/path/typed columns from the probe plus optional fileType/writeMode/compress/fieldDelimiter/encoding/fileName/kerberos/hadoopConfig options; template sample HA/kerberos/bloom blocks are removed unless explicitly requested)
- Other plugins are rejected with a pointer to the legacy `gen -r/-w` mode
- `--no-probe` restores the legacy behavior explicitly
- One known warning noise: semantically equivalent types (e.g. PostgreSQL `serial` vs `int4`) are reported as type mismatches; intentionally not silenced in v1
