### PR TITLE
fix(core): fail-fast scheduling, channel wait metrics and job lifecycle repairs

### DIFF
--- a/core/src/main/java/com/wgzhao/addax/core/element/TimestampColumn.java
+++ b/core/src/main/java/com/wgzhao/addax/core/element/TimestampColumn.java
@@ -79,10 +79,9 @@ public class TimestampColumn
     @Override
     public Double asDouble()
     {
-       if (null == this.getRawData()) {
-           return null;
-       }
-       return (Double) this.getRawData();
+        // the raw data is a Timestamp, never a Double; converting to epoch millis
+        // would silently change the value's meaning, so fail with a clear error
+        throw AddaxException.asAddaxException(ErrorCode.CONVERT_NOT_SUPPORT, "Timestamp type cannot be converted to Double.");
     }
 
     @Override

--- a/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
@@ -114,6 +114,13 @@ public class JobContainer
             isDryRun = configuration.getBool(CoreConstant.JOB_SETTING_DRY_RUN, false);
             if (isDryRun) {
                 LOG.info("The jobContainer begins to perform pre-check ...");
+                // mark the config before init() so the plugin job confs carry the flag
+                this.configuration.set(CoreConstant.JOB_CONTENT_READER_PARAMETER + ".dryRun", true);
+                this.configuration.set(CoreConstant.JOB_CONTENT_WRITER_PARAMETER + ".dryRun", true);
+                // ensure a communicator exists for the job plugin collector
+                if (super.getContainerCommunicator() == null) {
+                    super.setContainerCommunicator(new StandAloneJobContainerCommunicator(configuration));
+                }
                 this.init();
                 this.preCheck();
             }
@@ -142,7 +149,11 @@ public class JobContainer
             }
         }
         catch (OutOfMemoryError e) {
+            // release plugin resources, then let the OOM propagate so the job is
+            // reported as failed instead of exiting 0 as if it succeeded
+            hasException = true;
             this.destroy();
+            throw e;
         }
         catch (RuntimeException e) {
 
@@ -172,18 +183,15 @@ public class JobContainer
                     RUNTIME_ERROR, e);
         }
         finally {
-            if (!isDryRun) {
-
-                this.destroy();
-                this.endTimeStamp = System.currentTimeMillis();
-                if (!hasException) {
-                    VMInfo vmInfo = VMInfo.getVmInfo();
-                    if (vmInfo != null) {
-                        vmInfo.getDelta(false);
-                        LOG.debug(vmInfo.totalString());
-                    }
-                    this.logStatistics();
+            this.destroy();
+            this.endTimeStamp = System.currentTimeMillis();
+            if (!isDryRun && !hasException) {
+                VMInfo vmInfo = VMInfo.getVmInfo();
+                if (vmInfo != null) {
+                    vmInfo.getDelta(false);
+                    LOG.debug(vmInfo.totalString());
                 }
+                this.logStatistics();
             }
         }
     }
@@ -205,67 +213,35 @@ public class JobContainer
     {
         Thread.currentThread().setName("job-0");
 
+        // reuse the instances created by init(); only the collector needs re-attaching
         JobPluginCollector jobPluginCollector = new DefaultJobPluginCollector(
                 this.getContainerCommunicator());
-        this.jobReader = this.preCheckReaderInit(jobPluginCollector);
-        this.jobWriter = this.preCheckWriterInit(jobPluginCollector);
-    }
-
-    private Reader.Job preCheckReaderInit(JobPluginCollector jobPluginCollector)
-    {
-        this.readerPluginName = this.configuration.getString(CoreConstant.JOB_CONTENT_READER_NAME);
-        classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
-
-        Reader.Job jobReader = (Reader.Job) LoadUtil.loadJobPlugin(PluginType.READER, this.readerPluginName);
-
-        this.configuration.set(CoreConstant.JOB_CONTENT_READER_PARAMETER + ".dryRun", true);
-
-        // configure the jobConfig of reader
-        jobReader.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
-        // use writer parameters as peer for reader during pre-check
-        jobReader.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
-        jobReader.setJobPluginCollector(jobPluginCollector);
-
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-        return jobReader;
-    }
-
-    private Writer.Job preCheckWriterInit(JobPluginCollector jobPluginCollector)
-    {
-        this.writerPluginName = this.configuration.getString(CoreConstant.JOB_CONTENT_WRITER_NAME);
-        classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
-
-        Writer.Job jobWriter = (Writer.Job) LoadUtil.loadJobPlugin(PluginType.WRITER, this.writerPluginName);
-
-        this.configuration.set(CoreConstant.JOB_CONTENT_WRITER_PARAMETER + ".dryRun", true);
-
-        // set job config for writer
-        jobWriter.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
-        // set peer config (reader) for writer
-        jobWriter.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
-
-        jobWriter.setPeerPluginName(this.readerPluginName);
-        jobWriter.setJobPluginCollector(jobPluginCollector);
-
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-
-        return jobWriter;
+        this.jobReader.setJobPluginCollector(jobPluginCollector);
+        this.jobWriter.setJobPluginCollector(jobPluginCollector);
     }
 
     private void preCheckReader()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
-        LOG.info("The Reader.Job [{}] perform pre-check work .", this.readerPluginName);
-        this.jobReader.preCheck();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Reader.Job [{}] perform pre-check work .", this.readerPluginName);
+            this.jobReader.preCheck();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private void preCheckWriter()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
-        LOG.info("The Writer.Job [{}] perform pre-check work .", this.writerPluginName);
-        this.jobWriter.preCheck();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Writer.Job [{}] perform pre-check work .", this.writerPluginName);
+            this.jobWriter.preCheck();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     /*
@@ -309,13 +285,17 @@ public class JobContainer
 
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(handlerPluginType, handlerPluginName));
 
-        AbstractJobPlugin handler = LoadUtil.loadJobPlugin(handlerPluginType, handlerPluginName);
+        try {
+            AbstractJobPlugin handler = LoadUtil.loadJobPlugin(handlerPluginType, handlerPluginName);
 
-        JobPluginCollector jobPluginCollector = new DefaultJobPluginCollector(this.getContainerCommunicator());
-        handler.setJobPluginCollector(jobPluginCollector);
+            JobPluginCollector jobPluginCollector = new DefaultJobPluginCollector(this.getContainerCommunicator());
+            handler.setJobPluginCollector(jobPluginCollector);
 
-        handler.preHandler(configuration);
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+            handler.preHandler(configuration);
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
 
         LOG.info("After PreHandler: \n{}\n", Engine.filterJobConfiguration(configuration));
     }
@@ -341,13 +321,17 @@ public class JobContainer
 
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(handlerPluginType, handlerPluginName));
 
-        AbstractJobPlugin handler = LoadUtil.loadJobPlugin(handlerPluginType, handlerPluginName);
+        try {
+            AbstractJobPlugin handler = LoadUtil.loadJobPlugin(handlerPluginType, handlerPluginName);
 
-        JobPluginCollector jobPluginCollector = new DefaultJobPluginCollector(this.getContainerCommunicator());
-        handler.setJobPluginCollector(jobPluginCollector);
+            JobPluginCollector jobPluginCollector = new DefaultJobPluginCollector(this.getContainerCommunicator());
+            handler.setJobPluginCollector(jobPluginCollector);
 
-        handler.postHandler(configuration);
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+            handler.postHandler(configuration);
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     /*
@@ -387,9 +371,9 @@ public class JobContainer
         int needChannelNumberByByte = Integer.MAX_VALUE;
         int needChannelNumberByRecord = Integer.MAX_VALUE;
 
-        boolean isByteLimit = (this.configuration.getInt(CoreConstant.JOB_SETTING_SPEED_BYTE, 0) > 0);
+        boolean isByteLimit = (this.configuration.getLong(CoreConstant.JOB_SETTING_SPEED_BYTE, 0) > 0);
         if (isByteLimit) {
-            long globalLimitedByteSpeed = this.configuration.getInt(CoreConstant.JOB_SETTING_SPEED_BYTE, 10 * 1024 * 1024);
+            long globalLimitedByteSpeed = this.configuration.getLong(CoreConstant.JOB_SETTING_SPEED_BYTE, 10 * 1024 * 1024);
 
             // Under byte-rate limit, the per-channel byte limit must be set, otherwise fail
             Long channelLimitedByteSpeed = this.configuration.getLong(CoreConstant.CORE_TRANSPORT_CHANNEL_SPEED_BYTE, -1);
@@ -404,9 +388,9 @@ public class JobContainer
             LOG.info("Job set Max-Byte-Speed to {} bytes.", globalLimitedByteSpeed);
         }
 
-        boolean isRecordLimit = (this.configuration.getInt(CoreConstant.JOB_SETTING_SPEED_RECORD, 0)) > 0;
+        boolean isRecordLimit = (this.configuration.getLong(CoreConstant.JOB_SETTING_SPEED_RECORD, 0)) > 0;
         if (isRecordLimit) {
-            long globalLimitedRecordSpeed = this.configuration.getInt(CoreConstant.JOB_SETTING_SPEED_RECORD, 100000);
+            long globalLimitedRecordSpeed = this.configuration.getLong(CoreConstant.JOB_SETTING_SPEED_RECORD, 100000);
             Long channelLimitedRecordSpeed = this.configuration.getLong(CoreConstant.CORE_TRANSPORT_CHANNEL_SPEED_RECORD, -1);
             if (channelLimitedRecordSpeed == null || channelLimitedRecordSpeed <= 0) {
                 throw AddaxException.asAddaxException(CONFIG_ERROR,
@@ -611,18 +595,22 @@ public class JobContainer
         this.readerPluginName = this.configuration.getString(CoreConstant.JOB_CONTENT_READER_NAME);
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
 
-        Reader.Job jobReader = (Reader.Job) LoadUtil.loadJobPlugin(PluginType.READER, this.readerPluginName);
-        // set job config for reader
-        jobReader.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
+        try {
+            Reader.Job jobReader = (Reader.Job) LoadUtil.loadJobPlugin(PluginType.READER, this.readerPluginName);
+            // set job config for reader
+            jobReader.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
 
-        // set peer config (writer) for reader
-        jobReader.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
+            // set peer config (writer) for reader
+            jobReader.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
 
-        jobReader.setJobPluginCollector(jobPluginCollector);
-        jobReader.init();
+            jobReader.setJobPluginCollector(jobPluginCollector);
+            jobReader.init();
 
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-        return jobReader;
+            return jobReader;
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     /*
@@ -633,63 +621,80 @@ public class JobContainer
         this.writerPluginName = this.configuration.getString(CoreConstant.JOB_CONTENT_WRITER_NAME);
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
 
-        Writer.Job jobWriter = (Writer.Job) LoadUtil.loadJobPlugin(PluginType.WRITER, this.writerPluginName);
-        // set job config for writer
-        jobWriter.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
+        try {
+            Writer.Job jobWriter = (Writer.Job) LoadUtil.loadJobPlugin(PluginType.WRITER, this.writerPluginName);
+            // set job config for writer
+            jobWriter.setPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_WRITER_PARAMETER));
 
-        // set peer config (reader) for writer
-        jobWriter.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
+            // set peer config (reader) for writer
+            jobWriter.setPeerPluginJobConf(this.configuration.getConfiguration(CoreConstant.JOB_CONTENT_READER_PARAMETER));
 
-        jobWriter.setPeerPluginName(this.readerPluginName);
-        jobWriter.setJobPluginCollector(jobPluginCollector);
-        jobWriter.init();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-
-        return jobWriter;
+            jobWriter.setPeerPluginName(this.readerPluginName);
+            jobWriter.setJobPluginCollector(jobPluginCollector);
+            jobWriter.init();
+            return jobWriter;
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private void prepareJobReader()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
-        LOG.info("The Reader.Job [{}] perform prepare work .", this.readerPluginName);
-        this.jobReader.prepare();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Reader.Job [{}] perform prepare work .", this.readerPluginName);
+            this.jobReader.prepare();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private void prepareJobWriter()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
-        LOG.info("The Writer.Job [{}] perform prepare work .", this.writerPluginName);
-        this.jobWriter.prepare();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Writer.Job [{}] perform prepare work .", this.writerPluginName);
+            this.jobWriter.prepare();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private List<Configuration> doReaderSplit(int adviceNumber)
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
-        List<Configuration> readerSlicesConfigs = this.jobReader.split(adviceNumber);
-        if (readerSlicesConfigs == null || readerSlicesConfigs.isEmpty()) {
-            throw AddaxException.asAddaxException(EXECUTE_FAIL,
-                    "The number of tasks divided by the reader's job cannot be less than or equal to zero");
+        try {
+            List<Configuration> readerSlicesConfigs = this.jobReader.split(adviceNumber);
+            if (readerSlicesConfigs == null || readerSlicesConfigs.isEmpty()) {
+                throw AddaxException.asAddaxException(EXECUTE_FAIL,
+                        "The number of tasks divided by the reader's job cannot be less than or equal to zero");
+            }
+            LOG.info("The Reader.Job [{}] is divided into [{}] task(s).", this.readerPluginName, readerSlicesConfigs.size());
+            return readerSlicesConfigs;
         }
-        LOG.info("The Reader.Job [{}] is divided into [{}] task(s).", this.readerPluginName, readerSlicesConfigs.size());
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-        return readerSlicesConfigs;
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private List<Configuration> doWriterSplit(int readerTaskNumber)
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
-
-        List<Configuration> writerSlicesConfigs = this.jobWriter.split(readerTaskNumber);
-        if (writerSlicesConfigs == null || writerSlicesConfigs.isEmpty()) {
-            throw AddaxException.asAddaxException(EXECUTE_FAIL,
-                    "The number of tasks divided by the writer's job cannot be less than or equal to zero");
+        try {
+            List<Configuration> writerSlicesConfigs = this.jobWriter.split(readerTaskNumber);
+            if (writerSlicesConfigs == null || writerSlicesConfigs.isEmpty()) {
+                throw AddaxException.asAddaxException(EXECUTE_FAIL,
+                        "The number of tasks divided by the writer's job cannot be less than or equal to zero");
+            }
+            LOG.info("The Writer.Job [{}] is divided into [{}] task(s).", this.writerPluginName, writerSlicesConfigs.size());
+            return writerSlicesConfigs;
         }
-        LOG.info("The Writer.Job [{}] is divided into [{}] task(s).", this.writerPluginName, writerSlicesConfigs.size());
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
-
-        return writerSlicesConfigs;
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     /*
@@ -731,17 +736,25 @@ public class JobContainer
     private void postJobReader()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.READER, this.readerPluginName));
-        LOG.info("The Reader.Job [{}] perform post work.", this.readerPluginName);
-        this.jobReader.post();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Reader.Job [{}] perform post work.", this.readerPluginName);
+            this.jobReader.post();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     private void postJobWriter()
     {
         classLoaderSwapper.setCurrentThreadClassLoader(LoadUtil.getJarLoader(PluginType.WRITER, this.writerPluginName));
-        LOG.info("The Writer.Job [{}] perform post work.", this.writerPluginName);
-        this.jobWriter.post();
-        classLoaderSwapper.restoreCurrentThreadClassLoader();
+        try {
+            LOG.info("The Writer.Job [{}] perform post work.", this.writerPluginName);
+            this.jobWriter.post();
+        }
+        finally {
+            classLoaderSwapper.restoreCurrentThreadClassLoader();
+        }
     }
 
     /**

--- a/core/src/main/java/com/wgzhao/addax/core/job/scheduler/AbstractScheduler.java
+++ b/core/src/main/java/com/wgzhao/addax/core/job/scheduler/AbstractScheduler.java
@@ -100,8 +100,15 @@ public abstract class AbstractScheduler
             }
 
             // Enforce error limits ASAP to fail-fast
-            errorLimit.checkRecordLimit(nowJobContainerCommunication);
-            errorLimit.checkPercentageLimit(nowJobContainerCommunication);
+            try {
+                errorLimit.checkRecordLimit(nowJobContainerCommunication);
+                errorLimit.checkPercentageLimit(nowJobContainerCommunication);
+            }
+            catch (Exception e) {
+                // shut down the task-group executor before propagating the breach,
+                // otherwise its non-daemon threads keep running in embedded use
+                dealFailedStat(this.containerCommunicator, e);
+            }
 
             State state = nowJobContainerCommunication.getState();
             if (state == State.SUCCEEDED) {
@@ -122,10 +129,10 @@ public abstract class AbstractScheduler
                 TimeUnit.MILLISECONDS.sleep(jobSleepIntervalInMillSec);
             }
             catch (InterruptedException e) {
-                // Restore interrupt status and exit as failed
+                // Restore interrupt status and exit as failed, shutting down task groups
                 Thread.currentThread().interrupt();
                 LOG.error("The scheduler thread was interrupted.", e);
-                throw AddaxException.asAddaxException(RUNTIME_ERROR, e);
+                dealFailedStat(this.containerCommunicator, e);
             }
         }
     }

--- a/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
+++ b/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
@@ -116,7 +116,9 @@ public class VMInfo
     {
 
         try {
-            long curUptime = runtimeMXBean.getUptime();
+            // RuntimeMXBean.getUptime() returns millis while ThreadMXBean CPU times
+            // are nanos; convert to nanos so the ratio yields a correct percentage
+            long curUptime = runtimeMXBean.getUptime() * 1_000_000L;
             // Get CPU time by summing all thread CPU times
             long curProcessTime = getTotalThreadCpuTime();
 
@@ -142,8 +144,11 @@ public class VMInfo
                     processGCStatus.gcStatusMap.put(garbage.getName(), gcStatus);
                 }
 
+                // seed the builder with the previous snapshot so the delta is
+                // computed against the last round instead of zero
                 GCStatus.Builder builder = new GCStatus.Builder()
                         .name(gcStatus.name)
+                        .previous(gcStatus)
                         .setCurTotalGcCount(garbage.getCollectionCount())
                         .setCurTotalGcTime(garbage.getCollectionTime());
 
@@ -324,6 +329,23 @@ public class VMInfo
                 this.maxDeltaGCTime = Math.max(maxDeltaGCTime, curDeltaGCTime);
                 this.minDeltaGCTime = (minDeltaGCTime == -1) ?
                         curDeltaGCTime : Math.min(minDeltaGCTime, curDeltaGCTime);
+                return this;
+            }
+
+            /**
+             * Seed the builder with a previous snapshot so deltas and max/min
+             * values carry over across rounds.
+             */
+            public Builder previous(GCStatus previous)
+            {
+                if (previous != null) {
+                    this.totalGCCount = previous.totalGCCount();
+                    this.totalGCTime = previous.totalGCTime();
+                    this.maxDeltaGCCount = previous.maxDeltaGCCount();
+                    this.minDeltaGCCount = previous.minDeltaGCCount();
+                    this.maxDeltaGCTime = previous.maxDeltaGCTime();
+                    this.minDeltaGCTime = previous.minDeltaGCTime();
+                }
                 return this;
             }
 

--- a/core/src/main/java/com/wgzhao/addax/core/statistics/communication/Communication.java
+++ b/core/src/main/java/com/wgzhao/addax/core/statistics/communication/Communication.java
@@ -25,10 +25,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAdder;
 
 public class Communication
         extends BaseObject
@@ -36,12 +39,18 @@ public class Communication
 
     // Message about the task is given to the job
     // Made final and initialized at declaration to ensure the map reference never changes.
+    // CopyOnWriteArrayList values let plugin threads append while a collector thread merges.
     private final Map<String, List<String>> message = new ConcurrentHashMap<>();
-    private final Map<String, Number> counter = new ConcurrentHashMap<>();
+    // Per-key lock-free accumulators. A key lives in exactly one of the two maps
+    // (callers must not mix setLongCounter and setDoubleCounter on the same key).
+    private final Map<String, AtomicLong> longCounters = new ConcurrentHashMap<>();
+    private final Map<String, DoubleAdder> doubleCounters = new ConcurrentHashMap<>();
     // Running status
-    private State state;
-    private Throwable throwable;
-    private long timestamp;
+    // volatile: the timestamp/throwable written by a failing task thread must be
+    // visible to the task-group loop that observes state == FAILED
+    private volatile State state;
+    private volatile Throwable throwable;
+    private volatile long timestamp;
 
     /**
      * Create a new Communication with default values.
@@ -64,15 +73,11 @@ public class Communication
             return;
         }
         // copy counters
-        for (Map.Entry<String, Number> entry : source.getCounter().entrySet()) {
-            String key = entry.getKey();
-            Number value = entry.getValue();
-            if (value instanceof Long) {
-                this.setLongCounter(key, value.longValue());
-            }
-            else if (value instanceof Double) {
-                this.setDoubleCounter(key, value.doubleValue());
-            }
+        for (Map.Entry<String, AtomicLong> entry : source.longCounters.entrySet()) {
+            this.setLongCounter(entry.getKey(), entry.getValue().get());
+        }
+        for (Map.Entry<String, DoubleAdder> entry : source.doubleCounters.entrySet()) {
+            this.setDoubleCounter(entry.getKey(), entry.getValue().doubleValue());
         }
         // copy state/throwable/timestamp
         this.setState(source.getState(), true);
@@ -95,16 +100,24 @@ public class Communication
     private void init()
     {
         // clear the maps instead of reassigning to keep the references final
-        this.counter.clear();
+        this.longCounters.clear();
+        this.doubleCounters.clear();
         this.state = State.RUNNING;
         this.throwable = null;
         this.message.clear();
         this.timestamp = System.currentTimeMillis();
     }
 
+    /**
+     * Snapshot of all counters as a plain map. Callers only iterate the result;
+     * for live reads use the typed accessors.
+     */
     public Map<String, Number> getCounter()
     {
-        return this.counter;
+        Map<String, Number> snapshot = new HashMap<>(longCounters.size() + doubleCounters.size());
+        snapshot.putAll(longCounters);
+        snapshot.putAll(doubleCounters);
+        return snapshot;
     }
 
     public synchronized State getState()
@@ -171,72 +184,73 @@ public class Communication
         return message.get(key);
     }
 
-    public synchronized void addMessage(String key, String value)
+    public void addMessage(String key, String value)
     {
         Validate.isTrue(StringUtils.isNotBlank(key), "The key of the added message cannot be empty.");
-        List<String> valueList = this.message.computeIfAbsent(key, k -> new ArrayList<>());
+        List<String> valueList = this.message.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>());
 
         valueList.add(value);
     }
 
-    public synchronized Long getLongCounter(String key)
+    public Long getLongCounter(String key)
     {
-        Number value = this.counter.get(key);
-        return value == null ? 0 : value.longValue();
+        AtomicLong value = this.longCounters.get(key);
+        return value == null ? 0 : value.get();
     }
 
-    public synchronized void setLongCounter(String key, long value)
+    public void setLongCounter(String key, long value)
     {
         Validate.isTrue(StringUtils.isNotBlank(key), "The key of setting counter can not be empty.");
-        this.counter.put(key, value);
+        this.longCounters.put(key, new AtomicLong(value));
     }
 
-    public synchronized Double getDoubleCounter(String key)
+    /**
+     * Register a live accumulator so reads reflect its value without per-update writes.
+     * The caller keeps updating the {@link AtomicLong}; this communication only references it.
+     */
+    public void putLongCounter(String key, AtomicLong source)
     {
-        Number value = this.counter.get(key);
+        Validate.isTrue(StringUtils.isNotBlank(key), "The key of setting counter can not be empty.");
+        Validate.isTrue(source != null, "The counter source can not be null.");
+        this.longCounters.put(key, source);
+    }
 
+    public Double getDoubleCounter(String key)
+    {
+        DoubleAdder value = this.doubleCounters.get(key);
         return value == null ? 0.0d : value.doubleValue();
     }
 
-    public synchronized void setDoubleCounter(String key, double value)
+    public void setDoubleCounter(String key, double value)
     {
         Validate.isTrue(StringUtils.isNotBlank(key), "The key of setting counter can not be empty.");
-        this.counter.put(key, value);
+        DoubleAdder adder = new DoubleAdder();
+        adder.add(value);
+        this.doubleCounters.put(key, adder);
     }
 
-    public synchronized void increaseCounter(String key, long deltaValue)
+    public void increaseCounter(String key, long deltaValue)
     {
         Validate.isTrue(StringUtils.isNotBlank(key), "The key of the added counter can not be empty.");
 
-        // Use Map.merge to atomically update numeric counters. Primitive deltaValue is autoboxed to Long.
-        this.counter.merge(key, deltaValue, (oldVal, newVal) -> Long.sum(oldVal.longValue(), newVal.longValue()));
+        // lock-free per-key accumulation: no monitor, no boxing on the hot path
+        this.longCounters.computeIfAbsent(key, k -> new AtomicLong()).addAndGet(deltaValue);
     }
 
-    public synchronized void mergeFrom(Communication otherComm)
+    public void mergeFrom(Communication otherComm)
     {
         if (otherComm == null) {
             return;
         }
 
-        // merge counter, add otherComm's value to this, create if not exist
-        for (Entry<String, Number> entry : otherComm.getCounter().entrySet()) {
-            String key = entry.getKey();
-            Number otherValue = entry.getValue();
-            if (otherValue == null) {
-                continue;
-            }
-
-            // Use merge to combine numbers while preserving integer/double semantics
-            this.counter.merge(key, otherValue, (current, incoming) -> {
-                // both integer-like -> keep as Long
-                if (current instanceof Long && incoming instanceof Long) {
-                    return Long.sum(current.longValue(), incoming.longValue());
-                }
-                else {
-                    // otherwise, use double arithmetic
-                    return Double.sum(current.doubleValue(), incoming.doubleValue());
-                }
-            });
+        // merge counters: add otherComm's value to this, create if not exist
+        for (Map.Entry<String, AtomicLong> entry : otherComm.longCounters.entrySet()) {
+            this.longCounters.computeIfAbsent(entry.getKey(), k -> new AtomicLong())
+                    .addAndGet(entry.getValue().get());
+        }
+        for (Map.Entry<String, DoubleAdder> entry : otherComm.doubleCounters.entrySet()) {
+            this.doubleCounters.computeIfAbsent(entry.getKey(), k -> new DoubleAdder())
+                    .add(entry.getValue().doubleValue());
         }
 
         mergeStateFrom(otherComm);
@@ -244,9 +258,9 @@ public class Communication
         this.throwable = this.throwable == null ? otherComm.getThrowable() : this.throwable;
 
         // combine all messages
-        for (Entry<String, List<String>> entry : otherComm.getMessage().entrySet()) {
+        for (Map.Entry<String, List<String>> entry : otherComm.getMessage().entrySet()) {
             String key = entry.getKey();
-            List<String> valueList = this.message.computeIfAbsent(key, k -> new ArrayList<>());
+            List<String> valueList = this.message.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>());
 
             valueList.addAll(entry.getValue());
         }

--- a/core/src/main/java/com/wgzhao/addax/core/taskgroup/TaskGroupContainer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/taskgroup/TaskGroupContainer.java
@@ -147,6 +147,7 @@ public class TaskGroupContainer
         long lastReportTimeStamp = 0;
         Communication lastTaskGroupContainerCommunication = new Communication();
 
+        try {
         while (true) {
             boolean failedOrKilled = false;
             Map<Integer, Communication> communicationMap = containerCommunicator.getCommunicationMap();
@@ -220,10 +221,12 @@ public class TaskGroupContainer
                             reportTaskGroupCommunication(lastTaskGroupContainerCommunication, taskCountInThisTaskGroup);
                             throw AddaxException.asAddaxException(ErrorCode.WAIT_TIME_EXCEED, "The task fail over wait timed out.");
                         }
-                        else {
-                            lastExecutor.shutdown();
-                            continue;
-                        }
+                        // block deterministically until the previous attempt's threads are dead
+                        // before retrying, bounded by the remaining fail-over budget; a plugin
+                        // that ignores interrupts would otherwise keep writing concurrently
+                        // with the new attempt (duplicate writes)
+                        lastExecutor.shutdownAndWait(Math.min(sleepIntervalInMillSec, taskMaxWaitInMs - (now - failedTime)));
+                        continue;
                     }
                     else {
                         LOG.debug("TaskGroup[{}] TaskId[{}] AttemptCount[{}] has already shutdown",
@@ -281,6 +284,35 @@ public class TaskGroupContainer
 
         // final report for all taskGroup
         reportTaskGroupCommunication(lastTaskGroupContainerCommunication, taskCountInThisTaskGroup);
+        }
+        catch (Throwable e) {
+            // an exception escaping the loop before the first report would leave the
+            // task-group communication RUNNING forever and hang the whole job; mark it
+            // FAILED so the scheduler sees it within one collect cycle
+            shutdownAll(runTasks, taskFailedExecutorMap);
+            Communication comm = this.containerCommunicator.collect();
+            if (comm.getThrowable() == null) {
+                comm.setThrowable(e);
+            }
+            comm.setState(State.FAILED);
+            this.containerCommunicator.report(comm);
+            throw e instanceof AddaxException
+                    ? (AddaxException) e
+                    : AddaxException.asAddaxException(RUNTIME_ERROR, e);
+        }
+    }
+
+    /**
+     * Interrupt every running and failed task executor in the group.
+     */
+    private void shutdownAll(List<TaskExecutor> runTasks, Map<Integer, TaskExecutor> taskFailedExecutorMap)
+    {
+        for (TaskExecutor taskExecutor : runTasks) {
+            taskExecutor.shutdown();
+        }
+        for (TaskExecutor taskExecutor : taskFailedExecutorMap.values()) {
+            taskExecutor.shutdown();
+        }
     }
 
     /**
@@ -507,6 +539,25 @@ public class TaskGroupContainer
             }
             if (readerThread.isAlive()) {
                 readerThread.interrupt();
+            }
+        }
+
+        /**
+         * Shut down the attempt and wait up to {@code timeoutMs} for both threads to die.
+         */
+        private void shutdownAndWait(long timeoutMs)
+        {
+            this.shutdown();
+            try {
+                if (writerThread.isAlive()) {
+                    writerThread.join(timeoutMs);
+                }
+                if (readerThread.isAlive()) {
+                    readerThread.join(timeoutMs);
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/core/src/main/java/com/wgzhao/addax/core/taskgroup/runner/AbstractRunner.java
+++ b/core/src/main/java/com/wgzhao/addax/core/taskgroup/runner/AbstractRunner.java
@@ -125,9 +125,11 @@ public abstract class AbstractRunner
      */
     public void markFail(final Throwable throwable)
     {
-        mark(State.FAILED);
+        // publish timestamp/throwable before the FAILED state so the task-group loop
+        // that observes isFinished() is guaranteed to see them (no lost retry interval)
         this.runnerCommunication.setTimestamp(System.currentTimeMillis());
         this.runnerCommunication.setThrowable(throwable);
+        mark(State.FAILED);
     }
 
     /**

--- a/core/src/main/java/com/wgzhao/addax/core/transport/channel/Channel.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/channel/Channel.java
@@ -59,6 +59,7 @@ public abstract class Channel
     protected volatile AtomicLong waitReaderTime = new AtomicLong(0);
     protected volatile AtomicLong waitWriterTime = new AtomicLong(0);
     private Communication currentCommunication;
+    private boolean waitCountersRegistered = false;
 
     public Channel(Configuration configuration)
     {
@@ -114,6 +115,7 @@ public abstract class Channel
     {
         this.currentCommunication = communication;
         this.lastCommunication.reset();
+        this.waitCountersRegistered = false;
     }
 
     public void push(Record r)
@@ -179,8 +181,14 @@ public abstract class Channel
         currentCommunication.increaseCounter(CommunicationTool.READ_SUCCEED_RECORDS, recordSize);
         currentCommunication.increaseCounter(CommunicationTool.READ_SUCCEED_BYTES, byteSize);
 
-        currentCommunication.setLongCounter(CommunicationTool.WAIT_READER_TIME, waitReaderTime.get());
-        currentCommunication.setLongCounter(CommunicationTool.WAIT_WRITER_TIME, waitWriterTime.get());
+        // register the live wait-time accumulators once per communication instead of
+        // copying their values on every batch; waitReaderTime is written only by the
+        // pull side and waitWriterTime only by the push side, so live reads are safe
+        if (!waitCountersRegistered) {
+            currentCommunication.putLongCounter(CommunicationTool.WAIT_READER_TIME, waitReaderTime);
+            currentCommunication.putLongCounter(CommunicationTool.WAIT_WRITER_TIME, waitWriterTime);
+            waitCountersRegistered = true;
+        }
 
         boolean isChannelByteSpeedLimit = (this.byteSpeed > 0);
         boolean isChannelRecordSpeedLimit = (this.recordSpeed > 0);

--- a/core/src/main/java/com/wgzhao/addax/core/transport/channel/memory/MemoryChannel.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/channel/memory/MemoryChannel.java
@@ -86,11 +86,15 @@ public class MemoryChannel
         try {
             long startTime = System.nanoTime();
             this.queue.put(r);
-            waitReaderTime.addAndGet(System.nanoTime() - startTime);
+            // blocked waiting for the writer to drain the queue
+            waitWriterTime.addAndGet(System.nanoTime() - startTime);
             memoryBytes.addAndGet(r.getMemorySize());
         }
         catch (InterruptedException ex) {
+            // propagate so the record is not counted as delivered; a silently
+            // swallowed interrupt would leave the reader flag set and lose data
             Thread.currentThread().interrupt();
+            throw new IllegalStateException(ex);
         }
     }
 
@@ -105,7 +109,8 @@ public class MemoryChannel
                 notInsufficient.await(200L, TimeUnit.MILLISECONDS);
             }
             this.queue.addAll(rs);
-            waitReaderTime.addAndGet(System.nanoTime() - startTime);
+            // blocked waiting for the writer to drain the queue
+            waitWriterTime.addAndGet(System.nanoTime() - startTime);
             memoryBytes.addAndGet(bytes);
             notEmpty.signalAll();
         }
@@ -113,7 +118,10 @@ public class MemoryChannel
             throw AddaxException.asAddaxException(RUNTIME_ERROR, e);
         }
         finally {
-            lock.unlock();
+            // lockInterruptibly may throw before the lock is acquired
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
     }
 
@@ -123,6 +131,7 @@ public class MemoryChannel
         try {
             long startTime = System.nanoTime();
             Record r = this.queue.take();
+            // blocked waiting for the reader to fill the queue
             waitReaderTime.addAndGet(System.nanoTime() - startTime);
             memoryBytes.addAndGet(-r.getMemorySize());
             return r;
@@ -144,6 +153,7 @@ public class MemoryChannel
             while (this.queue.drainTo(rs, bufferSize) <= 0) {
                 notEmpty.await(200L, TimeUnit.MILLISECONDS);
             }
+            // blocked waiting for the reader to fill the queue
             waitReaderTime.addAndGet(System.nanoTime() - startTime);
             int bytes = getRecordBytes(rs);
             memoryBytes.addAndGet(-bytes);
@@ -153,7 +163,10 @@ public class MemoryChannel
             throw AddaxException.asAddaxException(RUNTIME_ERROR, e);
         }
         finally {
-            lock.unlock();
+            // lockInterruptibly may throw before the lock is acquired
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
     }
 

--- a/core/src/main/java/com/wgzhao/addax/core/transport/exchanger/TransformerExchanger.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/exchanger/TransformerExchanger.java
@@ -73,55 +73,65 @@ public abstract class TransformerExchanger
         long diffExhaustedTime = 0;
         String errorMsg = null;
         boolean failed = false;
-        for (TransformerExecution transformerInfoExec : transformerExecs) {
-            long startTs = System.nanoTime();
+        boolean loaderSwapped = false;
+        ClassLoader currentLoader = null;
+        try {
+            for (TransformerExecution transformerInfoExec : transformerExecs) {
+                long startTs = System.nanoTime();
 
-            if (transformerInfoExec.getClassLoader() != null) {
-                classLoaderSwapper.setCurrentThreadClassLoader(transformerInfoExec.getClassLoader());
-            }
-
-            /*
-             * Deferred validation of transformer parameters; throw directly if invalid rather than marking dirty.
-             * No need to validate parameters inside plugins except for plugin-specific ones like parameter count.
-             */
-            if (!transformerInfoExec.isChecked()) {
-
-                if (transformerInfoExec.getColumnIndex() != null
-                        && transformerInfoExec.getColumnIndex() >= record.getColumnNumber()) {
-                    throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                            String.format("columnIndex[%s] out of bound[%s]. name=%s",
-                                    transformerInfoExec.getColumnIndex(), record.getColumnNumber(),
-                                    transformerInfoExec.getTransformerName()));
+                // swap the thread context classloader only when it actually changes;
+                // native transformers (null loader) never trigger a swap
+                ClassLoader execLoader = transformerInfoExec.getClassLoader();
+                if (execLoader != null && execLoader != currentLoader) {
+                    classLoaderSwapper.setCurrentThreadClassLoader(execLoader);
+                    currentLoader = execLoader;
+                    loaderSwapped = true;
                 }
-                transformerInfoExec.setIsChecked(true);
-            }
 
-            try {
-                result = transformerInfoExec
-                        .getTransformer()
-                        .evaluate(result, transformerInfoExec.getContext(),
-                                transformerInfoExec.getFinalParas());
-            }
-            catch (Exception e) {
-                errorMsg = String.format("The transformer(%s) has encountered an exception(%s)",
-                        transformerInfoExec.getTransformerName(),
-                        e.getMessage());
-                failed = true;
-                break;
-            }
-            finally {
-                if (transformerInfoExec.getClassLoader() != null) {
-                    classLoaderSwapper.restoreCurrentThreadClassLoader();
+                /*
+                 * Deferred validation of transformer parameters; throw directly if invalid rather than marking dirty.
+                 * No need to validate parameters inside plugins except for plugin-specific ones like parameter count.
+                 */
+                if (!transformerInfoExec.isChecked()) {
+
+                    if (transformerInfoExec.getColumnIndex() != null
+                            && transformerInfoExec.getColumnIndex() >= record.getColumnNumber()) {
+                        throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                                String.format("columnIndex[%s] out of bound[%s]. name=%s",
+                                        transformerInfoExec.getColumnIndex(), record.getColumnNumber(),
+                                        transformerInfoExec.getTransformerName()));
+                    }
+                    transformerInfoExec.setIsChecked(true);
                 }
-            }
 
-            if (result == null) {
-                totalFilterRecords++;
-                break;
-            }
+                try {
+                    result = transformerInfoExec
+                            .getTransformer()
+                            .evaluate(result, transformerInfoExec.getContext(),
+                                    transformerInfoExec.getFinalParas());
+                }
+                catch (Exception e) {
+                    errorMsg = String.format("The transformer(%s) has encountered an exception(%s)",
+                            transformerInfoExec.getTransformerName(),
+                            e.getMessage());
+                    failed = true;
+                    break;
+                }
 
-            long diff = System.nanoTime() - startTs;
-            diffExhaustedTime += diff;
+                if (result == null) {
+                    totalFilterRecords++;
+                    break;
+                }
+
+                long diff = System.nanoTime() - startTs;
+                diffExhaustedTime += diff;
+            }
+        }
+        finally {
+            // restore exactly once per call if any swap happened
+            if (loaderSwapped) {
+                classLoaderSwapper.restoreCurrentThreadClassLoader();
+            }
         }
 
         totalExhaustedTime += diffExhaustedTime;

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/TransformerRegistry.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/TransformerRegistry.java
@@ -29,9 +29,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
 import static com.wgzhao.addax.core.util.container.CoreConstant.STORAGE_TRANSFORMER_HOME;
@@ -40,7 +40,8 @@ public class TransformerRegistry
 {
 
     private static final Logger LOG = LoggerFactory.getLogger(TransformerRegistry.class);
-    private static final Map<String, TransformerInfo> registeredTransformer = new HashMap<>();
+    // written from task-group threads via buildTransformerInfo, read by the exchangers
+    private static final Map<String, TransformerInfo> registeredTransformer = new ConcurrentHashMap<>();
 
     public static void loadTransformerFromLocalStorage()
     {
@@ -96,7 +97,9 @@ public class TransformerRegistry
                     each, funName, transformerPath, transformerConfiguration.beautify());
         }
 
-        try (JarLoader jarLoader = new JarLoader(new String[] {transformerPath})) {
+        JarLoader jarLoader = new JarLoader(new String[] {transformerPath});
+        boolean registered = false;
+        try {
             Class<?> transformerClass = jarLoader.loadClass(className);
             Object transformer = transformerClass.getConstructor().newInstance();
             if (ComplexTransformer.class.isAssignableFrom(transformer.getClass())) {
@@ -110,10 +113,23 @@ public class TransformerRegistry
             else {
                 LOG.error("Load Transformer class[{}] error, path = {}", className, transformerPath);
             }
+            registered = true;
         }
         catch (Exception e) {
             //error, skip function
             LOG.error("Skip transformer({}),load Transformer class error, path = {} ", each, transformerPath, e);
+        }
+        finally {
+            // keep the loader open for the registry lifetime so classes lazily
+            // loaded during evaluation still resolve; close it only on failure
+            if (!registered) {
+                try {
+                    jarLoader.close();
+                }
+                catch (Exception ignored) {
+                    // closing a failed loader is best-effort
+                }
+            }
         }
     }
 

--- a/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
@@ -151,9 +151,10 @@ public final class ConfigParser
 
         Configuration coreConfig = Configuration.from(new File(CONF_PATH));
         // apply the environment variables
-        coreConfig.getMap("entry.environment").forEach((k, v) -> {
-            System.setProperty(k, v.toString());
-        });
+        Map<String, Object> environment = coreConfig.getMap("entry.environment");
+        if (environment != null) {
+            environment.forEach((k, v) -> System.setProperty(k, v.toString()));
+        }
         return coreConfig;
     }
 

--- a/core/src/main/java/com/wgzhao/addax/core/util/Configuration.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/Configuration.java
@@ -100,8 +100,9 @@ public class Configuration
 
     public static Configuration from(File file)
     {
-        try {
-            return Configuration.from(IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8));
+        // try-with-resources so the stream is always closed (IOUtils.toString does not close it)
+        try (InputStream is = new FileInputStream(file)) {
+            return Configuration.from(IOUtils.toString(is, StandardCharsets.UTF_8));
         }
         catch (FileNotFoundException e) {
             throw AddaxException.asAddaxException(ErrorCode.CONFIG_ERROR, String.format("No such file: %s", file.getAbsolutePath()));
@@ -207,8 +208,28 @@ public class Configuration
         try {
             return this.findObject(path);
         }
-        catch (Exception e) {
+        catch (MissingConfigException e) {
+            // absent key or out-of-range index: treat as missing
             return null;
+        }
+        catch (IllegalArgumentException e) {
+            // malformed path or wrong intermediate type: fail loudly instead of
+            // silently applying defaults for typos
+            throw AddaxException.asAddaxException(ErrorCode.CONFIG_ERROR,
+                    String.format("Invalid configuration path [%s], reason: %s", path, e.getMessage()));
+        }
+    }
+
+    /**
+     * Signals a missing key or out-of-range index during path navigation,
+     * as opposed to a malformed path.
+     */
+    private static class MissingConfigException
+            extends RuntimeException
+    {
+        MissingConfigException(String message)
+        {
+            super(message);
         }
     }
 
@@ -916,7 +937,7 @@ public class Configuration
 
         Object result = ((Map<String, Object>) target).get(index);
         if (null == result) {
-            throw new IllegalArgumentException("The value of item '" + index + "'is null.");
+            throw new MissingConfigException("The value of item '" + index + "'is null.");
         }
 
         return result;
@@ -934,7 +955,13 @@ public class Configuration
             throw new IllegalArgumentException(String.format("The list subscript must be a numeric type, but the actual type is [%s].", index));
         }
 
-        return ((List<Object>) target).get(Integer.parseInt(index));
+        int i = Integer.parseInt(index);
+        List<Object> list = (List<Object>) target;
+        if (i >= list.size()) {
+            throw new MissingConfigException(String.format("The list index [%d] is out of range, the list size is [%d].", i, list.size()));
+        }
+
+        return list.get(i);
     }
 
     private List<Object> expand(List<Object> list, int size)

--- a/core/src/main/java/com/wgzhao/addax/core/util/RetryUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/RetryUtil.java
@@ -148,13 +148,9 @@ public final class RetryUtil
                 catch (Exception e) {
                     saveException = e;
                     if (null != retryExceptionClass && !retryExceptionClass.isEmpty()) {
-                        boolean needRetry = false;
-                        for (Class<?> eachExceptionClass : retryExceptionClass) {
-                            if (eachExceptionClass == e.getClass()) {
-                                needRetry = true;
-                                break;
-                            }
-                        }
+                        // isAssignableFrom so subclasses of a listed exception also trigger a retry
+                        boolean needRetry = retryExceptionClass.stream()
+                                .anyMatch(eachExceptionClass -> eachExceptionClass.isAssignableFrom(e.getClass()));
                         if (!needRetry) {
                             throw saveException;
                         }
@@ -177,8 +173,10 @@ public final class RetryUtil
                         try {
                             Thread.sleep(timeToSleep);
                         }
-                        catch (InterruptedException ignored) {
-                            // ignore interrupted exception
+                        catch (InterruptedException ie) {
+                            // restore the interrupt and abort retrying instead of sleeping on
+                            Thread.currentThread().interrupt();
+                            throw saveException;
                         }
 
                         long realTimeSleep = System.currentTimeMillis() - startTime;

--- a/core/src/main/java/com/wgzhao/addax/core/util/StrUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/StrUtil.java
@@ -38,7 +38,8 @@ public class StrUtil
 
     private static final long TB_IN_BYTES = 1024 * GB_IN_BYTES;
 
-    private static final DecimalFormat df = new DecimalFormat("0.00");
+    // DecimalFormat is not thread-safe; stringify is reachable from task threads
+    private static final ThreadLocal<DecimalFormat> DF = ThreadLocal.withInitial(() -> new DecimalFormat("0.00"));
 
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("(\\$)\\{?(\\w+)\\}?");
 
@@ -51,16 +52,16 @@ public class StrUtil
     public static String stringify(long byteNumber)
     {
         if (byteNumber / TB_IN_BYTES > 0) {
-            return df.format((double) byteNumber / (double) TB_IN_BYTES) + "TB";
+            return DF.get().format((double) byteNumber / (double) TB_IN_BYTES) + "TB";
         }
         else if (byteNumber / GB_IN_BYTES > 0) {
-            return df.format((double) byteNumber / (double) GB_IN_BYTES) + "GB";
+            return DF.get().format((double) byteNumber / (double) GB_IN_BYTES) + "GB";
         }
         else if (byteNumber / MB_IN_BYTES > 0) {
-            return df.format((double) byteNumber / (double) MB_IN_BYTES) + "MB";
+            return DF.get().format((double) byteNumber / (double) MB_IN_BYTES) + "MB";
         }
         else if (byteNumber / KB_IN_BYTES > 0) {
-            return df.format((double) byteNumber / (double) KB_IN_BYTES) + "KB";
+            return DF.get().format((double) byteNumber / (double) KB_IN_BYTES) + "KB";
         }
         else {
             return byteNumber + "B";


### PR DESCRIPTION
## Summary

Fixes 15 correctness defects in the `core` module found during a deep review of the runtime architecture: scheduler hangs, swallowed errors, channel wait-metric inversion, dry-run leaks, retry overlaps, and classloader/statistics bugs.

## What type of change is this?

- [x] Bugfix

## Changes

**Scheduler / task-group fail-fast**
- An exception escaping the `TaskGroupContainer` loop before its first report (e.g. `TaskExecutor` constructor failure) left the task-group communication `RUNNING` forever — the scheduler polled indefinitely and the job hung with no error. The loop is now wrapped in a catch-all that shuts down all task executors, marks the group FAILED, reports, and rethrows.
- Error-limit breaches and scheduler interrupts now go through `dealFailedStat`, so the task-group executor is always shut down (was leaking non-daemon threads in embedded use).
- Retry now waits deterministically for the old attempt's threads to die (`shutdownAndWait`, a bounded join) before restarting, preventing duplicate writes from plugins that ignore interrupts. Backoff/interval/max-wait semantics are unchanged.

**Channel / memory channel**
- Wait-time metrics were inverted: every operation accumulated into `waitReaderTime`, so `waitWriterTime` was always 0. Push-side waits now accumulate into `waitWriterTime`, pull-side into `waitReaderTime` (matches DataX upstream and the `ReaderRunner`/`WriterRunner` reporting).
- `doPush` silently dropped records on interrupt but still counted them as delivered; it now propagates the interrupt so the task fails instead of losing data.
- `doPushAll`/`doPullAll` could throw `IllegalMonitorStateException` on interrupt (unlock without owning the lock); guarded with `isHeldByCurrentThread`.
- Wait-time counters are now registered once per communication via `putLongCounter` instead of being rewritten on every batch.

**Job lifecycle**
- `OutOfMemoryError` was swallowed and the job exited 0 as successful; it now propagates after resource cleanup.
- Dry-run initialized plugins twice (`init()` plus preCheck creating a second pair) and destroyed neither; it now reuses the `init()` instances and always destroys plugins in `finally`, and a communicator is created before the collector is used (fixes a `DefaultJobPluginCollector` NPE).
- Speed limits over 2^31 wrapped negative and inverted the channel-count logic; now read via `getLong`.
- All 12 thread-context-classloader swap sites wrapped in `try/finally`.

**Statistics / config / utils**
- `Communication` counters are lock-free per-key accumulators; `state`/`throwable`/`timestamp` are volatile and published before `setState(FAILED)` so the retry interval is never skipped; message lists are `CopyOnWriteArrayList` (no more `ConcurrentModificationException` during merge).
- `Configuration.get` now distinguishes missing keys (returns null) from malformed paths (fails loudly with `CONFIG_ERROR`); `from(File)` no longer leaks the stream.
- `VMInfo` CPU% mixed nanos/millis (off by ~1e6) and GC deltas reset every report; both fixed.
- `RetryUtil` matches retry exceptions via `isAssignableFrom` (subclasses now retry) and restores interrupts instead of sleeping through them.
- `TransformerRegistry` keeps `JarLoader`s open for the registry lifetime so custom transformers with lazily-loaded classes work; the `TransformerExchanger` swaps the thread context classloader only when it changes.
- Misc: `ConfigParser` null-checks the environment map; `TimestampColumn.asDouble` throws `CONVERT_NOT_SUPPORT` instead of a guaranteed `ClassCastException`; `StrUtil` decimal format made thread-local.

## Motivation and Context

These defects were identified by three parallel deep-dive reviews of the core module (runtime architecture, hot-path logic, JDK-17 modernization opportunities). Several were reproduced locally: a plugin class loading failure hung the whole job forever on `master` (scheduler polling `RUNNING` forever); the fix branch fails fast with exit code 2.

## How has this been tested?

- `mvn clean package -DskipTests` from repo root (full build, all modules).
- Manual runs with a local addax home layout:
  1. `stream2txt.json` — exit 0, 1000 records / 26000 bytes written; snapshot now shows `WaitWriterTime 0.069s | WaitReaderTime 0.006s` (previously all wait time was attributed to the reader).
  2. Nonexistent plugin class — previously hung forever on `master`; now fails fast with exit code 2.
  3. `job.setting.dryRun: true` — "Pre-check passed", clean exit, no NPE.
  4. Invalid writer path (job-level init failure) — exit code 2 as expected.
- Retry/failover semantics verified by code trace (join preserves the retry interval, max-wait budget, and attempt counting).

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — no unit tests per project convention; verified by manual runs above
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

Core module robustness: fail-fast scheduling, correct channel wait metrics, dry-run and OOM handling, retry overlap prevention, thread-safe statistics.

## Breaking changes / Migration

- `Communication.getCounter()` now returns a snapshot map instead of the live map (internal callers only).
- Malformed configuration paths that previously fell back to defaults now fail with `CONFIG_ERROR` — check job/core configs for typos.
