### PR TITLE
refactor(core): JDK 17 modernization of the core module

### DIFF
--- a/core/src/main/java/com/wgzhao/addax/core/element/ColumnCast.java
+++ b/core/src/main/java/com/wgzhao/addax/core/element/ColumnCast.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang3.time.FastDateFormat;
 
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -87,7 +86,7 @@ class StringCast
         StringCast.datetimeFormat = configuration.getString("common.column.datetimeFormat",  "yyyy-MM-dd HH:mm:ss");
         StringCast.dateFormat = configuration.getString("common.column.dateFormat", "yyyy-MM-dd");
         StringCast.timeFormat = configuration.getString("common.column.timeFormat", "HH:mm:ss");
-        StringCast.extraFormats = configuration.getList("common.column.extraFormats", Collections.emptyList(), String.class);
+        StringCast.extraFormats = configuration.getList("common.column.extraFormats", List.of(), String.class);
         StringCast.timeZone = configuration.getString("common.column.timeZone", "GMT+8");
         StringCast.encoding = configuration.getString("common.column.encoding", "UTF-8");
 
@@ -173,21 +172,17 @@ class DateCast
             return null;
         }
 
-        switch (column.getSubType()) {
-            case DATE:
-                return DateFormatUtils.format(column.asDate(), DateCast.dateFormat,
-                        DateCast.timeZoner);
-            case TIME:
-                return DateFormatUtils.format(column.asDate(), DateCast.timeFormat,
-                        DateCast.timeZoner);
-            case DATETIME:
-                return DateFormatUtils.format(column.asDate(),
-                        DateCast.datetimeFormat, DateCast.timeZoner);
-            default:
-                throw AddaxException
-                        .asAddaxException(ErrorCode.CONVERT_NOT_SUPPORT,
-                                "An unsupported type occurred for the date type. Currently, only DATE/TIME/DATETIME are supported.");
-        }
+        return switch (column.getSubType()) {
+            case DATE -> DateFormatUtils.format(column.asDate(), DateCast.dateFormat,
+                    DateCast.timeZoner);
+            case TIME -> DateFormatUtils.format(column.asDate(), DateCast.timeFormat,
+                    DateCast.timeZoner);
+            case DATETIME -> DateFormatUtils.format(column.asDate(),
+                    DateCast.datetimeFormat, DateCast.timeZoner);
+            default -> throw AddaxException
+                    .asAddaxException(ErrorCode.CONVERT_NOT_SUPPORT,
+                            "An unsupported type occurred for the date type. Currently, only DATE/TIME/DATETIME are supported.");
+        };
     }
 }
 

--- a/core/src/main/java/com/wgzhao/addax/core/element/LongColumn.java
+++ b/core/src/main/java/com/wgzhao/addax/core/element/LongColumn.java
@@ -136,10 +136,8 @@ public class LongColumn
     @Override
     public Timestamp asTimestamp()
     {
-        if (this.getRawData() instanceof BigInteger) {
-            BigInteger b = (BigInteger) this.getRawData();
-            long l = b.longValue();
-            return new Timestamp(l);
+        if (this.getRawData() instanceof BigInteger b) {
+            return new Timestamp(b.longValue());
         }
         else {
             return new Timestamp((Long) this.getRawData());

--- a/core/src/main/java/com/wgzhao/addax/core/exception/AddaxException.java
+++ b/core/src/main/java/com/wgzhao/addax/core/exception/AddaxException.java
@@ -55,8 +55,8 @@ public class AddaxException
     /** Asaddaxexception. */
     public static AddaxException asAddaxException(ErrorCode errorCode, String message, Throwable cause)
     {
-        if (cause instanceof AddaxException) {
-            return (AddaxException) cause;
+        if (cause instanceof AddaxException addaxException) {
+            return addaxException;
         }
         return new AddaxException(errorCode, message, cause);
     }
@@ -64,8 +64,8 @@ public class AddaxException
     /** Asaddaxexception. */
     public static AddaxException asAddaxException(ErrorCode errorCode, Throwable cause)
     {
-        if (cause instanceof AddaxException) {
-            return (AddaxException) cause;
+        if (cause instanceof AddaxException addaxException) {
+            return addaxException;
         }
         return new AddaxException(errorCode, formatCauseMessage(cause), cause);
     }

--- a/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
@@ -577,27 +577,30 @@ public class JobContainer
             LOG.debug("The report contents: {}", jsonStr);
             postJobRunStatistic(jobResultReportUrl, timeoutMills, jsonStr);
         }
-        String statMsg = String.format("%n" + "%-26s: %-18s%n" + "%-26s: %-18s%n" + "%-26s: %19s%n"
-                        + "%-26s: %19s%n" + "%-26s: %19s%n" + "%-26s: %19s%n" + "%-26s: %19s%n" + "%-26s: %19s%n",
-                "Job start  at", dateFormat.format(startTimeStamp),
-                "Job end    at", dateFormat.format(endTimeStamp),
-                "Job took secs", totalCosts + "s",
-                "Total   bytes", totalReadBytes,
-                "Average   bps", StrUtil.stringify(byteSpeedPerSecond) + "/s",
-                "Average   rps", recordSpeedPerSecond + "rec/s",
-                "Number of rec", totalReadRecords,
-                "Failed record", totalErrorRecords
-        );
+        String statMsg = """
+                %n%-26s: %-18s%n%-26s: %-18s%n%-26s: %19s%n%-26s: %19s%n%-26s: %19s%n%-26s: %19s%n%-26s: %19s%n%-26s: %19s%n"""
+                .formatted(
+                        "Job start  at", dateFormat.format(startTimeStamp),
+                        "Job end    at", dateFormat.format(endTimeStamp),
+                        "Job took secs", totalCosts + "s",
+                        "Total   bytes", totalReadBytes,
+                        "Average   bps", StrUtil.stringify(byteSpeedPerSecond) + "/s",
+                        "Average   rps", recordSpeedPerSecond + "rec/s",
+                        "Number of rec", totalReadRecords,
+                        "Failed record", totalErrorRecords
+                );
         LOG.info(statMsg);
         final Long counterSucc = communication.getLongCounter(CommunicationTool.TRANSFORMER_SUCCEED_RECORDS);
         final Long counterFail = communication.getLongCounter(CommunicationTool.TRANSFORMER_FAILED_RECORDS);
         final Long counterFilter = communication.getLongCounter(CommunicationTool.TRANSFORMER_FILTER_RECORDS);
         if (counterSucc + counterFail + counterFilter > 0) {
-            String transStatMsg = String.format("%n" + "%-26s: %19s%n" + "%-26s: %19s%n" + "%-26s: %19s%n",
-                    "Transformer success records", counterSucc,
-                    "Transformer failed  records", counterFail,
-                    "Transformer filter  records", counterFilter
-            );
+            String transStatMsg = """
+                    %n%-26s: %19s%n%-26s: %19s%n%-26s: %19s%n"""
+                    .formatted(
+                            "Transformer success records", counterSucc,
+                            "Transformer failed  records", counterFail,
+                            "Transformer filter  records", counterFilter
+                    );
             LOG.info(transStatMsg);
         }
     }

--- a/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/job/JobContainer.java
@@ -57,6 +57,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.Map;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
@@ -503,8 +504,8 @@ public class JobContainer
 
     private void logStatistics()
     {
-        long totalCosts = (this.endTimeStamp - this.startTimeStamp) / 1000;
-        long transferCosts = (this.endTransferTimeStamp - this.startTransferTimeStamp) / 1000;
+        long totalCosts = TimeUnit.MILLISECONDS.toSeconds(this.endTimeStamp - this.startTimeStamp);
+        long transferCosts = TimeUnit.MILLISECONDS.toSeconds(this.endTransferTimeStamp - this.startTransferTimeStamp);
         if (0L == transferCosts) {
             transferCosts = 1L;
         }

--- a/core/src/main/java/com/wgzhao/addax/core/statistics/PerfRecord.java
+++ b/core/src/main/java/com/wgzhao/addax/core/statistics/PerfRecord.java
@@ -94,11 +94,9 @@ public class PerfRecord
         if (this == o) {
             return true;
         }
-        if (!(o instanceof PerfRecord)) {
+        if (!(o instanceof PerfRecord dst)) {
             return false;
         }
-
-        PerfRecord dst = (PerfRecord) o;
 
         if (this.getInstId() != dst.getInstId()) {
             return false;

--- a/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
+++ b/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
@@ -139,13 +139,8 @@ public class VMInfo
 
             // Update GC statistics
             for (GarbageCollectorMXBean garbage : garbageCollectorMXBeanList) {
-                GCStatus gcStatus = processGCStatus.gcStatusMap.get(garbage.getName());
-                if (gcStatus == null) {
-                    gcStatus = new GCStatus.Builder()
-                            .name(garbage.getName())
-                            .build();
-                    processGCStatus.gcStatusMap.put(garbage.getName(), gcStatus);
-                }
+                GCStatus gcStatus = processGCStatus.gcStatusMap.computeIfAbsent(garbage.getName(),
+                        name -> new GCStatus.Builder().name(name).build());
 
                 GCStatus.Builder builder = new GCStatus.Builder()
                         .name(gcStatus.name)
@@ -188,15 +183,8 @@ public class VMInfo
     {
         if (memoryPoolMXBeanList != null && !memoryPoolMXBeanList.isEmpty()) {
             memoryPoolMXBeanList.forEach(pool -> {
-                var memoryStatus = processMemoryStatus.memoryStatusMap.get(pool.getName());
-                if (memoryStatus == null) {
-                    memoryStatus = MemoryStatus.create(
-                            pool.getName(),
-                            pool.getUsage().getInit(),
-                            pool.getUsage().getMax()
-                    );
-                    processMemoryStatus.memoryStatusMap.put(pool.getName(), memoryStatus);
-                }
+                MemoryStatus memoryStatus = processMemoryStatus.memoryStatusMap.computeIfAbsent(pool.getName(),
+                        name -> MemoryStatus.create(name, pool.getUsage().getInit(), pool.getUsage().getMax()));
 
                 processMemoryStatus.memoryStatusMap.put(
                         pool.getName(),

--- a/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
+++ b/core/src/main/java/com/wgzhao/addax/core/statistics/VMInfo.java
@@ -98,13 +98,18 @@ public class VMInfo
 
     public String toString()
     {
-        return "The machine info  => \n\n"
-                + "\tosInfo: \t" + osInfo + "\n"
-                + "\tjvmInfo:\t" + jvmInfo + "\n"
-                + "\tcpu num:\t" + totalProcessorCount + "\n\n"
-                + startPhyOSStatus.toString() + "\n"
-                + processGCStatus + "\n"
-                + processMemoryStatus + "\n";
+        return """
+                The machine info  =>
+
+                \tosInfo: \t%s
+                \tjvmInfo:\t%s
+                \tcpu num:\t%d
+
+                %s
+                %s
+                %s
+                """.formatted(osInfo, jvmInfo, totalProcessorCount,
+                startPhyOSStatus.toString(), processGCStatus, processMemoryStatus);
     }
 
     public String totalString()

--- a/core/src/main/java/com/wgzhao/addax/core/taskgroup/TaskGroupContainer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/taskgroup/TaskGroupContainer.java
@@ -429,7 +429,7 @@ public class TaskGroupContainer
             TaskPluginCollector pluginCollector;
 
             switch (pluginType) {
-                case READER:
+                case READER -> {
                     newRunner = LoadUtil.loadPluginRunner(pluginType, this.taskConfig.getString(CoreConstant.JOB_READER_NAME));
                     newRunner.setJobConf(this.taskConfig.getConfiguration(CoreConstant.JOB_READER_PARAMETER));
 
@@ -447,8 +447,8 @@ public class TaskGroupContainer
 
                     // set the taskPlugin's collector to handle dirty data and job/task communication
                     newRunner.setTaskPluginCollector(pluginCollector);
-                    break;
-                case WRITER:
+                }
+                case WRITER -> {
                     newRunner = LoadUtil.loadPluginRunner(pluginType, this.taskConfig.getString(CoreConstant.JOB_WRITER_NAME));
                     newRunner.setJobConf(this.taskConfig.getConfiguration(CoreConstant.JOB_WRITER_PARAMETER));
 
@@ -457,9 +457,8 @@ public class TaskGroupContainer
 
                     // set the taskPlugin's collector to handle dirty data and job/task communication
                     newRunner.setTaskPluginCollector(pluginCollector);
-                    break;
-                default:
-                    throw AddaxException.asAddaxException(CONFIG_ERROR, "Cant generateRunner for:" + pluginType);
+                }
+                default -> throw AddaxException.asAddaxException(CONFIG_ERROR, "Cant generateRunner for:" + pluginType);
             }
 
             newRunner.setTaskGroupId(taskGroupId);

--- a/core/src/main/java/com/wgzhao/addax/core/transport/record/DefaultRecord.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/record/DefaultRecord.java
@@ -26,6 +26,7 @@ import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.util.ClassSize;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,8 +159,6 @@ public class DefaultRecord
         }
 
         int needToExpand = totalSize - columns.size();
-        while (needToExpand-- > 0) {
-            this.columns.add(null);
-        }
+        this.columns.addAll(Collections.nCopies(needToExpand, null));
     }
 }

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/FilterTransformer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/FilterTransformer.java
@@ -76,27 +76,17 @@ public class FilterTransformer
         Column column = record.getColumn(columnIndex);
 
         try {
-            switch (code) {
-                case "like":
-                    return doLike(record, value, column);
-                case "not like":
-                    return doNotLike(record, value, column);
-                case ">":
-                    return doGreat(record, value, column, false);
-                case "<":
-                    return doLess(record, value, column, false);
-                case "=":
-                case "==":
-                    return doEqual(record, value, column);
-                case "!=":
-                    return doNotEqual(record, value, column);
-                case ">=":
-                    return doGreat(record, value, column, true);
-                case "<=":
-                    return doLess(record, value, column, true);
-                default:
-                    throw new RuntimeException("dx_filter code:" + code + " is unsupported");
-            }
+            return switch (code) {
+                case "like" -> doLike(record, value, column);
+                case "not like" -> doNotLike(record, value, column);
+                case ">" -> doGreat(record, value, column, false);
+                case "<" -> doLess(record, value, column, false);
+                case "=", "==" -> doEqual(record, value, column);
+                case "!=" -> doNotEqual(record, value, column);
+                case ">=" -> doGreat(record, value, column, true);
+                case "<=" -> doLess(record, value, column, true);
+                default -> throw new RuntimeException("dx_filter code:" + code + " is unsupported");
+            };
         }
         catch (Exception e) {
             throw AddaxException.asAddaxException(

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/GroovyTransformer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/GroovyTransformer.java
@@ -109,13 +109,15 @@ public class GroovyTransformer
                 }
             }
         }
-        sb.append("import static com.wgzhao.addax.core.transport.transformer.GroovyTransformerStaticUtil.*;");
-        sb.append("import com.wgzhao.addax.core.element.*;");
-        sb.append("import com.wgzhao.addax.core.exception.AddaxException;");
-        sb.append("import com.wgzhao.addax.core.transport.transformer.Transformer;");
-        sb.append("import java.util.*;");
-        sb.append("public class RULE extends Transformer").append("{");
-        sb.append("public Record evaluate(Record record, Object... paras) {");
+        sb.append("""
+                import static com.wgzhao.addax.core.transport.transformer.GroovyTransformerStaticUtil.*;
+                import com.wgzhao.addax.core.element.*;
+                import com.wgzhao.addax.core.exception.AddaxException;
+                import com.wgzhao.addax.core.transport.transformer.Transformer;
+                import java.util.*;
+                public class RULE extends Transformer {
+                public Record evaluate(Record record, Object... paras) {
+                """);
         sb.append(expression);
         sb.append("}}");
 

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/GroovyTransformer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/GroovyTransformer.java
@@ -75,7 +75,7 @@ public class GroovyTransformer
         GroovyClassLoader loader = new GroovyClassLoader(GroovyTransformer.class.getClassLoader());
         String groovyRule = getGroovyRule(code, extraPackage);
 
-        Class groovyClass;
+        Class<?> groovyClass;
         try {
             groovyClass = loader.parseClass(groovyRule);
         }
@@ -86,12 +86,12 @@ public class GroovyTransformer
 
         try {
             Object t = groovyClass.getConstructor().newInstance();
-            if (!(t instanceof Transformer)) {
+            if (!(t instanceof Transformer transformer)) {
                 throw AddaxException.asAddaxException(
                         RUNTIME_ERROR,
                         "Addax bug! ");
             }
-            this.groovyTransformer = (Transformer) t;
+            this.groovyTransformer = transformer;
         }
         catch (Throwable ex) {
             throw AddaxException.asAddaxException(

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/MapTransformer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/MapTransformer.java
@@ -54,7 +54,6 @@ public class MapTransformer
         int columnIndex;
         String code;
         String value;
-        String newValue;
         Column column;
         int scale = 2; //默认精度
 
@@ -85,28 +84,15 @@ public class MapTransformer
         }
 
         try {
-            switch (code) {
-                case "+":
-                    newValue = add(column.asString(), value);
-                    break;
-                case "-":
-                    newValue = subtract(column.asString(), value);
-                    break;
-                case "*":
-                    newValue = multiply(column.asString(), value);
-                    break;
-                case "/":
-                    newValue = divide(column.asString(), value, scale);
-                    break;
-                case "%":
-                    newValue = mod(column.asString(), value);
-                    break;
-                case "^":
-                    newValue = pow(column.asString(), value);
-                    break;
-                default:
-                    throw new RuntimeException("dx_map can't support code:" + code);
-            }
+            String newValue = switch (code) {
+                case "+" -> add(column.asString(), value);
+                case "-" -> subtract(column.asString(), value);
+                case "*" -> multiply(column.asString(), value);
+                case "/" -> divide(column.asString(), value, scale);
+                case "%" -> mod(column.asString(), value);
+                case "^" -> pow(column.asString(), value);
+                default -> throw new RuntimeException("dx_map can't support code:" + code);
+            };
             record.setColumn(columnIndex, new StringColumn(newValue));
             return record;
         }

--- a/core/src/main/java/com/wgzhao/addax/core/transport/transformer/NullToDefaultTransformer.java
+++ b/core/src/main/java/com/wgzhao/addax/core/transport/transformer/NullToDefaultTransformer.java
@@ -94,11 +94,13 @@ public class NullToDefaultTransformer
 
         try {
             // paras[0] should be the parameter JSON string
-            String paramJson = null;
-            if (paras[0] instanceof String) {
-                paramJson = (String) paras[0];
-            } else if (paras[0] instanceof JSONObject) {
-                paramJson = ((JSONObject) paras[0]).toJSONString();
+            String paramJson;
+            if (paras[0] instanceof String s) {
+                paramJson = s;
+            } else if (paras[0] instanceof JSONObject jsonObject) {
+                paramJson = jsonObject.toJSONString();
+            } else {
+                paramJson = null;
             }
 
             if (paramJson == null) {
@@ -128,55 +130,22 @@ public class NullToDefaultTransformer
             return new StringColumn("");
         }
 
-        switch (type.toLowerCase()) {
-            case "string":
-            case "char":
-            case "varchar":
-            case "text":
-                return new StringColumn("");
+        return switch (type.toLowerCase()) {
+            case "string", "char", "varchar", "text" -> new StringColumn("");
 
-            case "int":
-            case "integer":
-            case "tinyint":
-            case "smallint":
-            case "mediumint":
-            case "bigint":
-            case "long":
-                return new LongColumn(0L);
+            case "int", "integer", "tinyint", "smallint", "mediumint", "bigint", "long" -> new LongColumn(0L);
 
-            case "float":
-            case "double":
-            case "decimal":
-            case "numeric":
-            case "real":
-                return new DoubleColumn(0.0);
+            case "float", "double", "decimal", "numeric", "real" -> new DoubleColumn(0.0);
 
-            case "bool":
-            case "boolean":
-                return new BoolColumn(false);
+            case "bool", "boolean" -> new BoolColumn(false);
 
-            case "date":
-            case "datetime":
-            case "timestamp":
-            case "time":
-                return new StringColumn("");
+            case "date", "datetime", "timestamp", "time" -> new StringColumn("");
 
-            case "bytes":
-            case "binary":
-            case "varbinary":
-            case "blob":
-                return new BytesColumn(new byte[0]);
+            case "bytes", "binary", "varbinary", "blob" -> new BytesColumn(new byte[0]);
 
-            case "array":
-            case "json":
-            case "jsonb":
-            case "object":
-            case "objectid":
-            case "java_object":
-                return new StringColumn("");
+            case "array", "json", "jsonb", "object", "objectid", "java_object" -> new StringColumn("");
 
-            default:
-                return new StringColumn("");
-        }
+            default -> new StringColumn("");
+        };
     }
 }

--- a/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
@@ -23,14 +23,14 @@ import com.wgzhao.addax.core.exception.AddaxException;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
@@ -192,11 +192,15 @@ public final class ConfigParser
             if (yamlObject == null) {
                 throw AddaxException.asAddaxException(CONFIG_ERROR, "The configure file is empty.");
             }
-            if (yamlObject instanceof Map) {
-                return Configuration.from((Map<String, Object>) yamlObject);
+            if (yamlObject instanceof Map<?, ?> map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> typedMap = (Map<String, Object>) map;
+                return Configuration.from(typedMap);
             }
-            if (yamlObject instanceof List) {
-                return Configuration.from((List<Object>) yamlObject);
+            if (yamlObject instanceof List<?> list) {
+                @SuppressWarnings("unchecked")
+                List<Object> typedList = (List<Object>) list;
+                return Configuration.from(typedList);
             }
             throw AddaxException.asAddaxException(CONFIG_ERROR,
                     "The configuration is incorrect. The configuration you provided is not in valid YAML format: top-level node must be a map or list.");
@@ -212,7 +216,7 @@ public final class ConfigParser
         String jobContent;
 
         try {
-            jobContent = FileUtils.readFileToString(new File(jobResource), StandardCharsets.UTF_8);
+            jobContent = Files.readString(Path.of(jobResource));
         }
         catch (IOException e) {
             throw AddaxException.asAddaxException(CONFIG_ERROR, "Failed to obtain job configuration:" + jobResource, e);

--- a/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/ConfigParser.java
@@ -110,12 +110,22 @@ public final class ConfigParser
      *
      * @param configuration {@link Configuration}
      */
+    /**
+     * Bridge the raw Map element type inferred from {@code Map.class} to a
+     * parameterized map list.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> castList(List<Map> list)
+    {
+        return (List<Map<String, Object>>) (List<?>) list;
+    }
+
     private static void upgradeJobConfig(Configuration configuration)
     {
         configuration.getNecessaryValue(JOB_CONTENT);
         if (configuration.getString(JOB_CONTENT).startsWith("[")) {
             // get the first element
-            List<Map> contentList = configuration.getList(JOB_CONTENT, Map.class);
+            List<Map<String, Object>> contentList = castList(configuration.getList(JOB_CONTENT, Map.class));
             if (contentList != null && !contentList.isEmpty()) {
                 configuration.set("job.content", contentList.get(0));
             }
@@ -123,7 +133,7 @@ public final class ConfigParser
         Configuration reader = configuration.getConfiguration(JOB_CONTENT_READER_PARAMETER);
         if (reader != null) {
             if (reader.getString(CONNECTION, "").startsWith("[")) {
-                List<Map> connectionList = configuration.getList(JOB_CONTENT_READER_PARAMETER_CONNECTION, Map.class);
+                List<Map<String, Object>> connectionList = castList(configuration.getList(JOB_CONTENT_READER_PARAMETER_CONNECTION, Map.class));
                 if (connectionList != null && !connectionList.isEmpty()) {
                     reader.set(CONNECTION, connectionList.get(0));
                 }
@@ -137,7 +147,7 @@ public final class ConfigParser
         Configuration writer = configuration.getConfiguration(JOB_CONTENT_WRITER_PARAMETER);
         if (writer != null) {
             if (writer.getString(CONNECTION, "").startsWith("[")) {
-                List<Map> connectionList = configuration.getList(JOB_CONTENT_WRITER_PARAMETER + ".connection", Map.class);
+                List<Map<String, Object>> connectionList = castList(configuration.getList(JOB_CONTENT_WRITER_PARAMETER + ".connection", Map.class));
                 if (connectionList != null && !connectionList.isEmpty()) {
                     writer.set(CONNECTION, connectionList.get(0));
                 }
@@ -256,7 +266,7 @@ public final class ConfigParser
 
     private static void validateJob(Configuration conf)
     {
-        final Map content = conf.getMap(JOB_CONTENT);
+        final Map<String, Object> content = conf.getMap(JOB_CONTENT);
         String[] validPaths = new String[] {JOB_CONTENT_READER, JOB_CONTENT_WRITER, JOB_CONTENT_READER_NAME,
                 JOB_CONTENT_READER_PARAMETER, JOB_CONTENT_WRITER_NAME, JOB_CONTENT_WRITER_PARAMETER};
 

--- a/core/src/main/java/com/wgzhao/addax/core/util/Configuration.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/Configuration.java
@@ -708,27 +708,26 @@ public class Configuration
 
     void getKeysRecursive(Object current, String path, Set<String> collect)
     {
-        boolean isRegularElement = !(current instanceof Map || current instanceof List);
-        if (isRegularElement) {
+        if (!(current instanceof Map || current instanceof List)) {
             collect.add(path);
             return;
         }
 
-        boolean isMap = current instanceof Map;
-        if (isMap) {
-            Map<String, Object> mapping = ((Map<String, Object>) current);
-            mapping.keySet().forEach(key -> {
+        if (current instanceof Map<?, ?> mapping) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) mapping;
+            map.keySet().forEach(key -> {
                 if (StringUtils.isBlank(path)) {
-                    getKeysRecursive(mapping.get(key), key.trim(), collect);
+                    getKeysRecursive(map.get(key), key.trim(), collect);
                 }
                 else {
-                    getKeysRecursive(mapping.get(key), path + "." + key.trim(), collect);
+                    getKeysRecursive(map.get(key), path + "." + key.trim(), collect);
                 }
             });
             return;
         }
 
-        List<Object> lists = (List<Object>) current;
+        List<?> lists = (List<?>) current;
         for (int i = 0; i < lists.size(); i++) {
             getKeysRecursive(lists.get(i), path + String.format("[%d]", i), collect);
         }
@@ -753,22 +752,24 @@ public class Configuration
 
     private Object extractConfiguration(Object object)
     {
-        if (object instanceof Configuration) {
-            return extractFromConfiguration(object);
+        if (object instanceof Configuration configuration) {
+            return extractFromConfiguration(configuration);
         }
 
-        if (object instanceof List) {
+        if (object instanceof List<?> list) {
             List<Object> result = new ArrayList<>();
-            for (Object each : (List<Object>) object) {
+            for (Object each : list) {
                 result.add(extractFromConfiguration(each));
             }
             return result;
         }
 
-        if (object instanceof Map) {
+        if (object instanceof Map<?, ?> map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> typed = (Map<String, Object>) map;
             Map<String, Object> result = new HashMap<>();
-            for (String key : ((Map<String, Object>) object).keySet()) {
-                result.put(key, extractFromConfiguration(((Map<String, Object>) object).get(key)));
+            for (String key : typed.keySet()) {
+                result.put(key, extractFromConfiguration(typed.get(key)));
             }
             return result;
         }
@@ -778,8 +779,8 @@ public class Configuration
 
     private Object extractFromConfiguration(Object object)
     {
-        if (object instanceof Configuration) {
-            return ((Configuration) object).getInternal();
+        if (object instanceof Configuration configuration) {
+            return configuration.getInternal();
         }
 
         return object;
@@ -834,15 +835,16 @@ public class Configuration
             Map<String, Object> mapping;
 
             // the current is not a map, so we replace it with a map and return the new map object
-            boolean isCurrentMap = current instanceof Map;
-            if (!isCurrentMap) {
+            if (!(current instanceof Map)) {
                 mapping = new HashMap<>();
                 mapping.put(path, buildObject(paths.subList(index + 1, paths.size()), value));
                 return mapping;
             }
 
             // the current is a map, but the key does not exist, so we need to insert the object and return the map
-            mapping = ((Map<String, Object>) current);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> currentMap = (Map<String, Object>) current;
+            mapping = currentMap;
             boolean hasSameKey = mapping.containsKey(path);
             if (!hasSameKey) {
                 mapping.put(path, buildObject(paths.subList(index + 1, paths.size()), value));
@@ -861,8 +863,7 @@ public class Configuration
             int listIndexer = getIndex(path);
 
             // 当前是list，直接新建并返回即可
-            boolean isCurrentList = current instanceof List;
-            if (!isCurrentList) {
+            if (!(current instanceof List)) {
                 lists = expand(new ArrayList<>(), listIndexer + 1);
                 lists.set(listIndexer, buildObject(paths.subList(index + 1, paths.size()), value));
                 return lists;
@@ -973,7 +974,7 @@ public class Configuration
 
     private List<String> split2List(String path)
     {
-        return Arrays.asList(StringUtils.split(split(path), "."));
+        return List.of(StringUtils.split(split(path), "."));
     }
 
     private void checkPath(String path)

--- a/core/src/main/java/com/wgzhao/addax/core/util/MathUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/MathUtil.java
@@ -531,6 +531,6 @@ public class MathUtil
      */
     private static boolean isBlank(String str)
     {
-        return null == str || str.trim().isEmpty();
+        return str == null || str.isBlank();
     }
 }

--- a/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
+++ b/core/src/main/java/com/wgzhao/addax/core/util/TransformerUtil.java
@@ -25,14 +25,13 @@ import com.wgzhao.addax.core.transport.transformer.TransformerExecutionParas;
 import com.wgzhao.addax.core.transport.transformer.TransformerInfo;
 import com.wgzhao.addax.core.transport.transformer.TransformerRegistry;
 import com.wgzhao.addax.core.util.container.CoreConstant;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -110,7 +109,7 @@ public class TransformerUtil
                                 "the codeFile [" + codeFile + "]does not exists or is unreadable!");
                     }
                     try {
-                        code = FileUtils.readFileToString(file, Charset.defaultCharset());
+                        code = Files.readString(file.toPath());
                     }
                     catch (IOException e) {
                         throw AddaxException.asAddaxException(IO_ERROR,
@@ -147,7 +146,7 @@ public class TransformerUtil
                                 "the codeFile [" + codeFile + "]does not exists or is unreadable!");
                     }
                     try {
-                        code = FileUtils.readFileToString(file, Charset.defaultCharset());
+                        code = Files.readString(file.toPath());
                     }
                     catch (IOException e) {
                         throw AddaxException.asAddaxException(IO_ERROR,


### PR DESCRIPTION
## Summary

JDK 17 language modernization of the `core` module (Java 17 is already the build target): instanceof pattern variables, arrow switch expressions, text blocks, and newer stdlib APIs. Final features only — no preview features.

## What type of change is this?

- [x] Chore / Refactor

## Changes

**Hot paths first**
- instanceof pattern variables: `AddaxException.asAddaxException` (every wrapped exception), `LongColumn.asTimestamp`, `PerfRecord.equals`, `NullToDefaultTransformer.parseColumnTypes`, `GroovyTransformer.initGroovyTransformer`, `Configuration` tree navigators (`getKeysRecursive`, `extractConfiguration`, `setObjectRecursive`), YAML top-level dispatch in `ConfigParser`.
- Arrow switch expressions: `MapTransformer` (dx_map operators, per-record), `FilterTransformer` (dx_filter codes, per-record), `NullToDefaultTransformer.createDefaultColumn`, `ColumnCast.DateCast.asString`, `TaskGroupContainer.generateRunner`.
- `MathUtil.isBlank` → `String.isBlank()` (avoids a per-record `trim()` allocation).

**Cold paths**
- Text blocks: generated Groovy rule in `GroovyTransformer`, `VMInfo.toString`, `JobContainer` statistics messages. The Engine ASCII banner is untouched (contains backslash sequences requiring escaping).
- `Files.readString` replaces `FileUtils.readFileToString` (UTF-8 explicit) in `ConfigParser` and `TransformerUtil`; `List.of()` replaces `Collections.emptyList()`/`Arrays.asList`.
- `computeIfAbsent` in `VMInfo`; `TimeUnit.MILLISECONDS.toSeconds` in `JobContainer`; `Collections.nCopies` in `DefaultRecord`.
- Raw `List<Map>` types parameterized in `ConfigParser`; raw `Class` → `Class<?>` in `GroovyTransformer`.

**Explicitly avoided**
- Type-pattern switch on the `FilterTransformer` column dispatch (Java 17 preview) — kept as plain instanceof.
- `RangeSplitUtil`'s `Pair` return type (public plugin-facing API) — left unchanged.

## Motivation and Context

The module still carried Java-8-era idioms despite targeting Java 17; this reduces ceremony and improves readability, with the hot-path conversions done first. Behavior is identical throughout.

## How has this been tested?

- `mvn clean package -DskipTests` from repo root (full build, all modules).
- Manual run of `stream2txt.json`: exit 0, 1000 records / 26000 bytes, identical output to the pre-refactor baseline.
- The Groovy transformer generated-source text block compiles and runs (class skeleton is equivalent modulo line breaks).

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — no unit tests per project convention; verified by manual runs
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

No user-visible change.

## Breaking changes / Migration

None.
