### PR TITLE
fix(lib-rdbms): parenthesize user where clause in split queries

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
@@ -104,10 +104,16 @@ public class SingleTableSplitUtil
         }
 
         StringJoiner allQuerySql = new StringJoiner("\n");
+        // wrap the user where clause in parentheses so that a top-level OR inside it cannot
+        // swallow the appended range predicates (AND binds tighter than OR in SQL)
+        String queryPrefix = hasWhere
+                ? String.format(Constant.QUERY_SQL_TEMPLATE, column, table, "(" + where + ")")
+                : buildQuerySql(column, table, null);
+        String rangeSeparator = hasWhere ? " AND " : " WHERE ";
 
         for (String range : rangeList) {
             var tempConfig = configuration.clone();
-            var tempQuerySql = buildQuerySql(column, table, where) + (hasWhere ? " AND " : " WHERE ") + range;
+            var tempQuerySql = queryPrefix + rangeSeparator + range;
 
             allQuerySql.add(tempQuerySql);
             tempConfig.set(Key.QUERY_SQL, tempQuerySql);
@@ -116,9 +122,7 @@ public class SingleTableSplitUtil
 
         if (configuration.getBool("pkExistsNull", false)) {
             var tempConfig = configuration.clone();
-            var tempQuerySql = buildQuerySql(column, table, where)
-                    + (hasWhere ? " AND " : " WHERE ")
-                    + splitPkName + " IS NULL";
+            var tempQuerySql = queryPrefix + rangeSeparator + splitPkName + " IS NULL";
             allQuerySql.add(tempQuerySql);
             tempConfig.set(Key.QUERY_SQL, tempQuerySql);
             pluginParams.add(tempConfig);


### PR DESCRIPTION
## Summary

Split range predicates were appended to the user-supplied WHERE clause with ` AND ` without parentheses. A top-level `OR` in the user WHERE (e.g. `status='new' OR status='hold'`) then swallowed the range predicates, so every slice re-read the rows of the first disjunct and duplicated output rows. The same flaw applied to the `pk IS NULL` slice.

## What type of change is this?
- [x] Bugfix

## Changes

- Wrap the user WHERE clause in parentheses once before appending each split range and the NULL-key slice in `SingleTableSplitUtil.splitSingleTable`.
- WHERE-free and single-disjunct queries are byte-identical to before.

## Motivation and Context

Rows were duplicated silently when split-pk jobs used a WHERE containing OR.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

None.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
