### PR TITLE
fix(lib-rdbms): count null split keys in the same min/max scan

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
@@ -180,31 +180,18 @@ public class SingleTableSplitUtil
             while (DBUtil.asyncResultSetNext(rs)) {
                 minMaxPackage.setMin(rs.getObject(1));
                 minMaxPackage.setMax(rs.getObject(2));
+                // count of NULL split keys gathered from the same scan
+                Object nullCount = rs.getObject(3);
+                if (nullCount != null && ((Number) nullCount).longValue() > 0) {
+                    LOG.info("the split key has null value.");
+                    configuration.set("pkExistsNull", true);
+                }
             }
-
-            checkForNullValues(configuration, conn, splitPK, table, where);
 
             return minMaxPackage;
         }
         catch (AddaxException e) {
             throw e;
-        }
-        catch (Exception e) {
-            throw AddaxException.asAddaxException(CONFIG_ERROR, "Failed to split the table.", e);
-        }
-    }
-
-    private static void checkForNullValues(Configuration configuration, Connection conn, String splitPK, String table, String where)
-    {
-        String nullCheckSql = StringUtils.isBlank(where)
-                ? "SELECT count(*) FROM " + table + " WHERE " + splitPK + " IS NULL"
-                : "SELECT count(*) FROM " + table + " WHERE " + where + " AND " + splitPK + " IS NULL";
-
-        try (ResultSet rs = DBUtil.query(conn, nullCheckSql, 1)) {
-            if (rs.next() && rs.getInt(1) > 0) {
-                LOG.info("the split key has null value.");
-                configuration.set("pkExistsNull", true);
-            }
         }
         catch (Exception e) {
             throw AddaxException.asAddaxException(CONFIG_ERROR, "Failed to split the table.", e);
@@ -382,7 +369,9 @@ public class SingleTableSplitUtil
     }
 
     /**
-     * Generates SQL query to get the minimum and maximum values of the primary key column.
+     * Generates SQL query to get the minimum and maximum values of the primary key column
+     * plus the count of NULL split keys in a single table scan.
+     * MIN/MAX ignore NULL values by themselves, so no IS NOT NULL predicate is needed.
      *
      * @param splitPK The primary key column name (should be properly quoted)
      * @param table The table name to query
@@ -391,10 +380,12 @@ public class SingleTableSplitUtil
      */
     public static String genPKSql(String splitPK, String table, String where)
     {
-        String pkRangeSQL = String.format("SELECT MIN(%s), MAX(%s) FROM %s", splitPK, splitPK, table);
+        String pkRangeSQL = String.format(
+                "SELECT MIN(%s), MAX(%s), SUM(CASE WHEN %s IS NULL THEN 1 ELSE 0 END) FROM %s",
+                splitPK, splitPK, splitPK, table);
 
         if (StringUtils.isNotBlank(where)) {
-            return String.format("%s WHERE (%s AND %s IS NOT NULL)", pkRangeSQL, where, splitPK);
+            return String.format("%s WHERE (%s)", pkRangeSQL, where);
         }
 
         return pkRangeSQL;


### PR DESCRIPTION
## Summary

Splitting a table ran two full-table scans at job phase: one for MIN/MAX of the split key and a second `SELECT count(*) ... WHERE pk IS NULL` in `checkForNullValues`.

## What type of change is this?
- [x] Bugfix

## Changes

- `genPKSql` now also selects `SUM(CASE WHEN pk IS NULL THEN 1 ELSE 0 END)` in the same scan.
- The NULL-split-key flag is derived from that third column and `checkForNullValues` is removed.
- The obsolete `IS NOT NULL` predicate is dropped since MIN/MAX ignore NULL values.

## Motivation and Context

One scan instead of two during split for every table with a split key.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

The generated SQL stays portable; databases whose MIN/MAX skip NULLs natively produce identical MIN/MAX results.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
