### PR TITLE
fix(lib-rdbms): escape string split keys when building range sql

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
@@ -351,8 +351,8 @@ public class SingleTableSplitUtil
         String middleSqlTemplate = isString ? "%s >= '%s' AND %s < '%s'" : "%s >= %s AND %s < %s";
         String lastSqlTemplate = isString ? "%s >= '%s' AND %s <= '%s'" : "%s >= %s AND %s <= %s";
 
-        Object min = minMaxPackage.getMin();
-        Object max = minMaxPackage.getMax();
+        Object min = isString ? escapeSqlLiteral(String.valueOf(minMaxPackage.getMin())) : minMaxPackage.getMin();
+        Object max = isString ? escapeSqlLiteral(String.valueOf(minMaxPackage.getMax())) : minMaxPackage.getMax();
         if (rangeValues.isEmpty()) {
             rangeSql.add(String.format(singleSqlTemplate, pkName, min, pkName, max));
             return rangeSql;
@@ -360,7 +360,9 @@ public class SingleTableSplitUtil
 
         var allPoints = new ArrayList<>(rangeValues.size() + 1);
         allPoints.add(min);
-        allPoints.addAll(rangeValues);
+        // split points of string keys are already generated from a safe character set,
+        // but escape them too in case a future generator emits raw key data
+        rangeValues.forEach(v -> allPoints.add(isString ? escapeSqlLiteral(String.valueOf(v)) : v));
 
         for (int i = 0; i < allPoints.size() - 1; i++) {
             rangeSql.add(String.format(middleSqlTemplate, pkName, allPoints.get(i), pkName, allPoints.get(i + 1)));
@@ -369,6 +371,15 @@ public class SingleTableSplitUtil
         rangeSql.add(String.format(lastSqlTemplate, pkName, allPoints.get(allPoints.size() - 1), pkName, max));
 
         return rangeSql;
+    }
+
+    /**
+     * Doubles embedded single quotes so the value can be embedded in a SQL string literal.
+     * min/max of a string split key come straight from table data and may contain quotes.
+     */
+    private static String escapeSqlLiteral(String value)
+    {
+        return value.replace("'", "''");
     }
 
     private static boolean isLongType(int type)


### PR DESCRIPTION
## Summary

min/max of a string split key come straight from table data and were interpolated into single-quoted SQL literals verbatim. A key containing a single quote (e.g. `O'Brien`) made every split query a syntax error and opened a data-driven SQL-injection surface.

## What type of change is this?
- [x] Bugfix

## Changes

- Single quotes in string split keys and generated split points are doubled before embedding in the range predicates of `genAllTypePkRangeWhereClause`.

## Motivation and Context

Split queries on string keys with embedded quotes crashed; values could also rewrite the generated WHERE semantics.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

Quote-free and numeric keys are unchanged.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
