### PR TITLE
fix(lib-rdbms): compute split points overflow-safe

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/MinMaxPackage.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/MinMaxPackage.java
@@ -17,6 +17,7 @@
 
 package com.wgzhao.addax.rdbms.reader.util;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -170,12 +171,19 @@ public class MinMaxPackage
         }
         List<Object> result = new java.util.ArrayList<>();
         if (isLong()) {
-            long min = Long.parseLong(this.min.toString());
-            long max = Long.parseLong(this.max.toString());
-            long step = (max - min) / splitNum;
+            // MIN/MAX of an UNSIGNED BIGINT may exceed Long.MAX_VALUE and the span of two
+            // sparse extremes can overflow a long, so compute the split points in BigInteger
+            BigInteger min = new BigInteger(this.min.toString());
+            BigInteger max = new BigInteger(this.max.toString());
+            BigInteger step = max.subtract(min).divide(BigInteger.valueOf(splitNum));
+            if (step.signum() == 0) {
+                // the span is smaller than the requested number of slices; one whole-range
+                // slice is safer than degenerate empty slices (mirrors the FLOAT branch)
+                return result;
+            }
             // exclude min and max
             for (long i = 1; i < splitNum; i++) {
-                result.add(min + i * step);
+                result.add(min.add(step.multiply(BigInteger.valueOf(i))));
             }
             return result;
         }

--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/SingleTableSplitUtil.java
@@ -448,9 +448,12 @@ public class SingleTableSplitUtil
                 return min; // They're equal, can't create a midpoint
             }
 
-            // Return a value with length between min and max
+            // min is a prefix of max: pad min with a printable filler up to a length strictly
+            // between the two, so the result stays inside (min, max). A filler below max's next
+            // character keeps the value below max; any filler keeps it above min (longer).
             int targetLength = (int) (minChars.length + fraction * (maxChars.length - minChars.length));
-            return new String(minChars, 0, targetLength);
+            char padChar = maxChars[minChars.length] > '0' ? '0' : (char) Math.max(' ', maxChars[minChars.length] - 1);
+            return min + String.valueOf(padChar).repeat(targetLength - minChars.length);
         }
 
         // Create a result array based on minChars


### PR DESCRIPTION
## Summary

Three defects in split-point generation for primary keys: (1) splitting a BIGINT UNSIGNED key holding values beyond 2^63 crashed with `NumberFormatException` in `Long.parseLong`; (2) a signed span wider than `Long.MAX_VALUE` overflowed `(max - min)` into a negative step, degenerating most slices; (3) string keys where min is a short prefix of max threw `StringIndexOutOfBoundsException` while composing the midpoint.

## What type of change is this?
- [x] Bugfix

## Changes

- `MinMaxPackage.genSplitPoint` computes long-key split points in `BigInteger`, and falls back to one whole-range slice when the span is smaller than the requested slice count.
- `SingleTableSplitUtil.calculateStringBetween` pads a prefix-min with a printable filler instead of overrunning the character array.

## Motivation and Context

These crashes/degenerate ranges surfaced with real UNSIGNED BIGINT keys after the read path already handled such values.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

Degenerate-span fallback mirrors the existing FLOAT branch behavior.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
