### PR TITLE
fix(lib-rdbms): repair auto pk probe sql for sybase and clickhouse

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/GetPrimaryKeyUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/util/GetPrimaryKeyUtil.java
@@ -95,7 +95,8 @@ public class GetPrimaryKeyUtil
             }
         }
         catch (SQLException e) {
-            LOG.debug(e.getMessage());
+            // a broken probe query must not fail silently: report why no split key was found
+            LOG.warn("Failed to detect the split key of table {}: {}", table, e.getMessage());
             return null;
         }
 
@@ -206,7 +207,7 @@ public class GetPrimaryKeyUtil
                         """.formatted(schemaExpr, tableName);
             }
             case ClickHouse -> {
-                var schemaExpr = schema == null ? "SELECT currentDatabase()) " : "'" + schema + "'";
+                var schemaExpr = schema == null ? "(SELECT currentDatabase()) " : "'" + schema + "'";
                 yield """
                         SELECT name as column_name, type as column_type, 'PRI' as key_type
                         FROM system.columns
@@ -260,8 +261,8 @@ public class GetPrimaryKeyUtil
                         JOIN systypes t ON c.usertype = t.usertype
                     WHERE
                         o.name = '%s'
-                        AND (i.status & 2 = 2 OR i.status & 2048 = 2048) ")
-                        AND (SELECT COUNT(*) FROM sysindexkeys k WHERE k.id = i.id AND k.indid = i.indid) = 1 ")
+                        AND (i.status & 2 = 2 OR i.status & 2048 = 2048)
+                        AND (SELECT COUNT(*) FROM sysindexkeys k WHERE k.id = i.id AND k.indid = i.indid) = 1
                         AND o.uid = USER_ID('%s')
                     ORDER BY
                         CASE WHEN i.status & 2048 = 2048 THEN 0 ELSE 1 END,  t.name


### PR DESCRIPTION
## Summary

The Sybase probe text block carried stray `")` characters and the ClickHouse probe produced `database = SELECT currentDatabase())` when no schema was configured, so every auto-pk probe on these databases threw a syntax error. The exception was logged at debug level only and the probe silently returned null, so `splitPk` detection never worked.

## What type of change is this?
- [x] Bugfix

## Changes

- Remove the stray characters from the Sybase text block.
- Parenthesize the ClickHouse `currentDatabase()` expression.
- Log probe failures at warn level with the table name.

## Motivation and Context

autoPk users on Sybase/ClickHouse silently fell back to single-task sequential reads.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

None.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
