### PR TITLE
fix(lib-rdbms): stop forwarding null records after dirty collection

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/CommonRdbmsReader.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/CommonRdbmsReader.java
@@ -313,6 +313,11 @@ public class CommonRdbmsReader
                 int columnNumber, TaskPluginCollector taskPluginCollector)
         {
             Record record = buildRecord(recordSender, rs, metaData, columnNumber, taskPluginCollector);
+            if (record == null) {
+                // the row already failed conversion and was reported via collectDirtyRecord,
+                // so it must not be forwarded (sendToWriter rejects null records)
+                return;
+            }
             recordSender.sendToWriter(record);
         }
 


### PR DESCRIPTION
## Summary

When a single row failed type conversion, `buildRecord` collected the dirty record and returned null, but `transportOneRecord` still passed null to `sendToWriter`, whose `Validate.notNull` aborted the whole task instead of letting dirty-record tolerance work.

## What type of change is this?
- [x] Bugfix

## Changes

- Skip rows whose `buildRecord` returned null in `CommonRdbmsReader.Task.transportOneRecord`.

## Motivation and Context

One unreadable cell killed the whole job with a misleading SQL-query error, bypassing configured dirty-record limits.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

None.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
