### PR TITLE
fix(lib-rdbms): align merge key matching between template and record partition

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
@@ -45,12 +45,9 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
 import static com.wgzhao.addax.core.spi.ErrorCode.EXECUTE_FAIL;
@@ -330,6 +327,18 @@ public class CommonRdbmsWriter
         protected List<Map<String, Object>> resultSetMetaData;
 
         /**
+         * whether each configured column belongs to the merge key (Oracle/SQLServer update mode).
+         * Computed once per task so batch inserts never re-parse the write mode or re-match keys.
+         */
+        private boolean[] mergeKeyPositions;
+
+        /**
+         * column indexes that reorder a record to the merge template parameter order:
+         * key columns first, then non-key columns, then all columns again
+         */
+        private int[] mergeRecordOrder;
+
+        /**
          * Constructs a new Task instance for the specified database type.
          *
          * @param dataBaseType The database type this task will operate on
@@ -404,19 +413,24 @@ public class CommonRdbmsWriter
             if ((this.dataBaseType == DataBaseType.Oracle || this.dataBaseType == DataBaseType.SQLServer)
                     && !"insert".equalsIgnoreCase(this.writeMode)) {
                 LOG.info("write {} using {} mode", this.dataBaseType, this.writeMode);
+                String[] keyColumns = WriterUtil.getStrings(this.writeMode);
                 List<String> columnsOne = new ArrayList<>();
                 List<String> columnsTwo = new ArrayList<>();
-                String merge = this.writeMode;
-                String[] sArray = WriterUtil.getStrings(merge);
-                for (String s : this.columns) {
-                    if (Arrays.asList(sArray).contains(s)) {
-                        columnsOne.add(s);
+                this.mergeKeyPositions = new boolean[this.columns.size()];
+                for (int k = 0; k < this.columns.size(); k++) {
+                    String column = this.columns.get(k);
+                    if (WriterUtil.isKeyColumn(keyColumns, column)) {
+                        columnsOne.add(column);
+                        this.mergeKeyPositions[k] = true;
+                    }
+                    else {
+                        columnsTwo.add(column);
                     }
                 }
-                for (String s : this.columns) {
-                    if (!Arrays.asList(sArray).contains(s)) {
-                        columnsTwo.add(s);
-                    }
+                if (columnsOne.isEmpty()) {
+                    throw AddaxException.asAddaxException(CONFIG_ERROR,
+                            "None of the configured columns matches the update key columns declared in writeMode ["
+                                    + this.writeMode + "], configured columns: " + StringUtils.join(this.columns, ","));
                 }
                 int i = 0;
                 for (String column : columnsOne) {
@@ -425,6 +439,22 @@ public class CommonRdbmsWriter
                 for (String column : columnsTwo) {
                     mergeColumns.add(i++, column);
                 }
+                // the merge template binds key columns, then non-key columns, then all columns again
+                List<Integer> order = new ArrayList<>(this.columns.size() * 2);
+                for (int k = 0; k < this.columns.size(); k++) {
+                    if (this.mergeKeyPositions[k]) {
+                        order.add(k);
+                    }
+                }
+                for (int k = 0; k < this.columns.size(); k++) {
+                    if (!this.mergeKeyPositions[k]) {
+                        order.add(k);
+                    }
+                }
+                for (int k = 0; k < this.columns.size(); k++) {
+                    order.add(k);
+                }
+                this.mergeRecordOrder = order.stream().mapToInt(Integer::intValue).toArray();
             }
             mergeColumns.addAll(this.columns);
 
@@ -546,33 +576,11 @@ public class CommonRdbmsWriter
                     connection.setAutoCommit(false);
                 }
                 preparedStatement = connection.prepareStatement(writeRecordSql);
-                if ((this.dataBaseType == DataBaseType.Oracle || this.dataBaseType == DataBaseType.SQLServer)
-                        && !"insert".equalsIgnoreCase(writeMode)) {
-                    String[] sArray = WriterUtil.getStrings(this.writeMode);
-                    Set<String> mergeKeySet = new HashSet<>(java.util.Arrays.asList(sArray));
+                if (mergeRecordOrder != null) {
+                    // Oracle/SQLServer update: reorder each record to the merge parameter order
+                    // computed once in startWriteWithConnection
                     for (Record record : buffer) {
-                        List<Column> recordOne = new ArrayList<>(this.columns.size() * 2);
-                        // key columns first
-                        for (int j = 0; j < this.columns.size(); j++) {
-                            String col = columns.get(j);
-                            if (mergeKeySet.contains(col)) {
-                                recordOne.add(record.getColumn(j));
-                            }
-                        }
-                        // non-key columns next
-                        for (int j = 0; j < this.columns.size(); j++) {
-                            String col = columns.get(j);
-                            if (!mergeKeySet.contains(col)) {
-                                recordOne.add(record.getColumn(j));
-                            }
-                        }
-                        // all columns again for update placeholders
-                        for (int j = 0; j < this.columns.size(); j++) {
-                            recordOne.add(record.getColumn(j));
-                        }
-                        for (int j = 0; j < recordOne.size(); j++) {
-                            record.setColumn(j, recordOne.get(j));
-                        }
+                        reorderRecord(record, mergeRecordOrder);
                         preparedStatement = fillPreparedStatement(preparedStatement, record);
                         preparedStatement.addBatch();
                     }
@@ -601,6 +609,22 @@ public class CommonRdbmsWriter
             }
             finally {
                 DBUtil.closeDBResources(preparedStatement, null);
+            }
+        }
+
+        /**
+         * Reorders the columns of a record in place according to the given index order.
+         * The original columns are read into a temporary list first, because setColumn
+         * overwrites positions that later indexes may still reference.
+         */
+        private static void reorderRecord(Record record, int[] order)
+        {
+            List<Column> reordered = new ArrayList<>(order.length);
+            for (int pos : order) {
+                reordered.add(record.getColumn(pos));
+            }
+            for (int j = 0; j < reordered.size(); j++) {
+                record.setColumn(j, reordered.get(j));
             }
         }
 

--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/WriterUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/WriterUtil.java
@@ -280,7 +280,7 @@ public final class WriterUtil
         for (int i = 0; i < columnHolders.size(); i++) {
             String columnHolder = columnHolders.get(i);
             // If this is a key column used for matching records
-            if (Arrays.stream(keyColumns).anyMatch(s -> s.equalsIgnoreCase(columnHolder))) {
+            if (isKeyColumn(keyColumns, columnHolder)) {
                 if (!isFirstKeyColumn) {
                     mergeSql.append(", ");
                     joinCondition.append(" AND ");
@@ -304,7 +304,7 @@ public final class WriterUtil
         boolean isFirstUpdateColumn = true;
         for (int i = 0; i < columnHolders.size(); i++) {
             String columnHolder = columnHolders.get(i);
-            if (Arrays.stream(keyColumns).noneMatch(s -> s.equalsIgnoreCase(columnHolder))) {
+            if (!isKeyColumn(keyColumns, columnHolder)) {
                 if (!isFirstUpdateColumn) {
                     updateClause.append(", ");
                 }
@@ -335,6 +335,42 @@ public final class WriterUtil
         merge = merge.replace(")", "");
         merge = merge.replace(" ", "");
         return merge.split(",");
+    }
+
+    /**
+     * Whether the column takes part in the merge/update key matching.
+     * Column names expanded from a "*" wildcard come back quoted ("ID", [ID]) and keys may
+     * differ in case, so both sides are compared unquoted and case-insensitively.
+     *
+     * @param keyColumns the key columns parsed from the write mode
+     * @param columnName the column to test
+     * @return true when the column matches one of the keys
+     */
+    public static boolean isKeyColumn(String[] keyColumns, String columnName)
+    {
+        if (columnName == null) {
+            return false;
+        }
+        String normalized = unquoteColumnName(columnName);
+        for (String key : keyColumns) {
+            if (unquoteColumnName(key).equalsIgnoreCase(normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String unquoteColumnName(String name)
+    {
+        String trimmed = name.trim();
+        if (trimmed.length() >= 2) {
+            char first = trimmed.charAt(0);
+            char last = trimmed.charAt(trimmed.length() - 1);
+            if ((first == '`' && last == '`') || (first == '"' && last == '"') || (first == '[' && last == ']')) {
+                return trimmed.substring(1, trimmed.length() - 1);
+            }
+        }
+        return trimmed;
     }
 
     /**


### PR DESCRIPTION
## Summary

The Oracle/SQLServer merge template matched update keys with `equalsIgnoreCase` while the runtime record partition used a case-sensitive `HashSet`, and columns expanded from `"*"` come back quoted (`"ID"`, `[ID]`) so they never matched the bare keys. Divergent matching produced an empty `ON ()` clause (invalid SQL; every row silently collected as dirty with a success exit) or bound values to the wrong placeholders, silently updating the wrong rows.

## What type of change is this?
- [x] Bugfix

## Changes

- All three sites (template building, `mergeColumns` metadata order, per-record reorder) now share `WriterUtil.isKeyColumn`, comparing unquoted names case-insensitively.
- Key parsing, partition flags and the reorder index list are computed once per task instead of per batch.
- A write mode whose keys match no configured column fails fast with a config error at task start.

## Motivation and Context

Mixed-case keys or wildcard-expanded quoted columns produced invalid SQL or silently wrong updates.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

Suggested merge order: this PR and `perf/writer-batch-binding` touch adjacent regions of `doBatchInsert` and may need a small manual resolution when merged sequentially.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
