### PR TITLE
perf(lib-rdbms): precompute binding metadata and reuse the batch statement

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
@@ -329,6 +329,17 @@ public class CommonRdbmsWriter
         /** Metadata information about target table columns */
         protected List<Map<String, Object>> resultSetMetaData;
 
+        // per-column binding metadata extracted once from resultSetMetaData (one-based indexes)
+        // so the per-record bind loop stops boxing and re-looking-up maps for every cell
+        private int[] bindingSqlTypes;
+        private int[] bindingScales;
+        private int[] bindingPrecisions;
+        private String[] bindingTypeNames;
+        private String[] bindingColumnNames;
+
+        /** Prepared statement reused across batches; recreated only after a failed batch */
+        private PreparedStatement batchStatement;
+
         /**
          * Constructs a new Task instance for the specified database type.
          *
@@ -429,6 +440,7 @@ public class CommonRdbmsWriter
             mergeColumns.addAll(this.columns);
 
             this.resultSetMetaData = DBUtil.getColumnMetaData(connection, this.table, StringUtils.join(mergeColumns, ","));
+            ensureBindingArrays();
 
             // combine the insert statement
             calcWriteRecordSql();
@@ -465,6 +477,9 @@ public class CommonRdbmsWriter
             }
             finally {
                 writeBuffer.clear();
+                // release the reused statement before returning the connection to the pool
+                DBUtil.closeDBResources(null, batchStatement, null);
+                batchStatement = null;
                 DBUtil.closeDBResources(null, null, connection);
             }
         }
@@ -545,7 +560,12 @@ public class CommonRdbmsWriter
                 if (supportCommit) {
                     connection.setAutoCommit(false);
                 }
-                preparedStatement = connection.prepareStatement(writeRecordSql);
+                // prepare the SQL once per task and reuse it across batches;
+                // the statement is dropped again only after a failed batch
+                if (batchStatement == null) {
+                    batchStatement = connection.prepareStatement(writeRecordSql);
+                }
+                preparedStatement = batchStatement;
                 if ((this.dataBaseType == DataBaseType.Oracle || this.dataBaseType == DataBaseType.SQLServer)
                         && !"insert".equalsIgnoreCase(writeMode)) {
                     String[] sArray = WriterUtil.getStrings(this.writeMode);
@@ -584,12 +604,17 @@ public class CommonRdbmsWriter
                     }
                 }
                 preparedStatement.executeBatch();
+                // free the batch buffer so the same statement serves the next batch
+                preparedStatement.clearBatch();
                 if (supportCommit) {
                     connection.commit();
                 }
             }
             catch (SQLException e) {
                 LOG.warn("Rolling back the write, try to write one line at a time. because: {}", e.getMessage());
+                // the failed statement may hold a partial batch; close it so the next batch re-prepares
+                DBUtil.closeDBResources(null, batchStatement, null);
+                batchStatement = null;
                 if (supportCommit) {
                     connection.rollback();
                 }
@@ -598,9 +623,6 @@ public class CommonRdbmsWriter
             catch (Exception e) {
                 throw AddaxException.asAddaxException(
                         EXECUTE_FAIL, e);
-            }
-            finally {
-                DBUtil.closeDBResources(preparedStatement, null);
             }
         }
 
@@ -652,11 +674,36 @@ public class CommonRdbmsWriter
                 throws SQLException
         {
             LOG.debug("Record info: {}", record);
+            ensureBindingArrays();
             for (int i = 1, len = record.getColumnNumber(); i <= len; i++) {
-                int columnSqlType = (int) this.resultSetMetaData.get(i).get("type");
-                preparedStatement = fillPreparedStatementColumnType(preparedStatement, i, columnSqlType, record.getColumn(i - 1));
+                preparedStatement = fillPreparedStatementColumnType(preparedStatement, i, bindingSqlTypes[i], record.getColumn(i - 1));
             }
             return preparedStatement;
+        }
+
+        /**
+         * Extracts the row-invariant binding metadata (sql type, scale, precision and names)
+         * from resultSetMetaData once per task instead of per record per cell.
+         */
+        private void ensureBindingArrays()
+        {
+            if (bindingSqlTypes != null || resultSetMetaData == null) {
+                return;
+            }
+            int size = resultSetMetaData.size();
+            bindingSqlTypes = new int[size];
+            bindingScales = new int[size];
+            bindingPrecisions = new int[size];
+            bindingTypeNames = new String[size];
+            bindingColumnNames = new String[size];
+            for (int i = 1; i < size; i++) {
+                Map<String, Object> map = resultSetMetaData.get(i);
+                bindingSqlTypes[i] = (int) map.get("type");
+                bindingScales[i] = (int) map.get("scale");
+                bindingPrecisions[i] = (int) map.get("precision");
+                bindingTypeNames[i] = String.valueOf(map.get("typeName"));
+                bindingColumnNames[i] = String.valueOf(map.get("name"));
+            }
         }
 
         /**
@@ -711,7 +758,7 @@ public class CommonRdbmsWriter
 
                 case Types.NUMERIC:
                 case Types.DECIMAL:
-                    if ((int) this.resultSetMetaData.get(columnIndex).get("scale") == 0) {
+                    if (bindingScales[columnIndex] == 0) {
                         if (column.getType() == Column.Type.STRING) {
                             preparedStatement.setBigDecimal(columnIndex, new BigDecimal(column.asString()));
                         } else {
@@ -782,7 +829,7 @@ public class CommonRdbmsWriter
                 // warn: bit(>1) -> Types.VARBINARY using setBytes
                 case Types.BIT:
                     // bit(1) -> setBoolean; bit(>1) -> treat as VARBINARY and use setBytes
-                    if ((int) this.resultSetMetaData.get(columnIndex).get("precision") == 1) {
+                    if (bindingPrecisions[columnIndex] == 1) {
                         preparedStatement.setBoolean(columnIndex, column.asBoolean());
                     }
                     else {
@@ -795,12 +842,11 @@ public class CommonRdbmsWriter
                     break;
 
                 default:
-                    Map<String, Object> map = this.resultSetMetaData.get(columnIndex);
                     throw AddaxException.asAddaxException(
                             NOT_SUPPORT_TYPE,
-                            "Not support the type: field name: " + map.get("name")
-                                    + "The SQL type: " + map.get("type")
-                                    + "The Java type: " + map.get("typeName"));
+                            "Not support the type: field name: " + bindingColumnNames[columnIndex]
+                                    + "The SQL type: " + bindingSqlTypes[columnIndex]
+                                    + "The Java type: " + bindingTypeNames[columnIndex]);
             }
             return preparedStatement;
         }


### PR DESCRIPTION
## Summary

The per-record bind loop fetched and unboxed column-metadata maps for every cell (up to three `HashMap.get` calls per cell per row) and each batch re-prepared the identical SQL text, adding a driver round trip and server-side re-parse per batch.

## What type of change is this?
- [x] Performance improvement

## Changes

- Extract sql type, scale, precision, type name and column name once per task into plain arrays and index them in `fillPreparedStatement` / `fillPreparedStatementColumnType`.
- Prepare the insert statement once per task and `clearBatch()` after each `executeBatch`, recreating it only after a failed batch; close it with the connection at task end.

## Motivation and Context

With millions of rows x dozens of columns the map lookups and per-batch prepares are measurable CPU and network waste.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

Error handling and the dirty-record fallback path are unchanged. Merge-order note as in `fix/merge-key-matching`.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
