### PR TITLE
fix(lib-rdbms): reject out-of-range strings bound to bigint targets

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
@@ -275,6 +275,11 @@ public class CommonRdbmsWriter
         /** Constant for SQL parameter placeholder */
         private static final String VALUE_HOLDER = "?";
 
+        /** Bounds of the BIGINT column types used for the client-side range check */
+        private static final BigDecimal BIGINT_SIGNED_MIN = BigDecimal.valueOf(Long.MIN_VALUE);
+        private static final BigDecimal BIGINT_SIGNED_MAX = BigDecimal.valueOf(Long.MAX_VALUE);
+        private static final BigDecimal BIGINT_UNSIGNED_MAX = new BigDecimal("18446744073709551615");
+
         /** Basic message template for logging context information */
         protected static String basicMessage;
 
@@ -702,9 +707,22 @@ public class CommonRdbmsWriter
 
                 case Types.BIGINT:
                     if (column.getType() == Column.Type.STRING) {
-                        // value from UNSIGNED BIGINT overflow; use BigDecimal to preserve precision
-                        preparedStatement.setBigDecimal(columnIndex, new BigDecimal(column.asString()));
-                    } else {
+                        // string cells may carry UNSIGNED BIGINT values beyond Long.MAX_VALUE;
+                        // validate client-side so an out-of-range value fails loudly as a dirty
+                        // record instead of being clamped or rounded silently by the server
+                        BigDecimal decimalValue = new BigDecimal(column.asString());
+                        String typeName = String.valueOf(this.resultSetMetaData.get(columnIndex).get("typeName"));
+                        BigDecimal lower = typeName.toUpperCase().contains("UNSIGNED") ? BigDecimal.ZERO : BIGINT_SIGNED_MIN;
+                        BigDecimal upper = typeName.toUpperCase().contains("UNSIGNED") ? BIGINT_UNSIGNED_MAX : BIGINT_SIGNED_MAX;
+                        if (decimalValue.stripTrailingZeros().scale() > 0
+                                || decimalValue.compareTo(lower) < 0
+                                || decimalValue.compareTo(upper) > 0) {
+                            throw new SQLException("Value [" + column.asString() + "] of column " + columnIndex
+                                    + " is out of range for a " + typeName + " target column");
+                        }
+                        preparedStatement.setBigDecimal(columnIndex, decimalValue);
+                    }
+                    else {
                         preparedStatement.setLong(columnIndex, column.asLong());
                     }
                     break;


### PR DESCRIPTION
## Summary

When BIGINT targets receive STRING cells the code binds `setBigDecimal` directly. Values beyond the target range are then silently clamped by MySQL/MariaDB in non-strict mode (data corruption with a success exit code) or turn whole batches dirty in strict mode; the former `asLong` overflow check that failed loudly is gone. Non-integral strings such as `12.9` also bypass validation.

## What type of change is this?
- [x] Bugfix

## Changes

- Validate STRING cells client-side in the BIGINT case: the value must be integral and inside the target range, using the declared column type name to pick signed vs unsigned bounds (`BIGINT UNSIGNED` allows up to 2^64-1).
- Violations raise a `SQLException` that routes the row through the dirty-record path.

## Motivation and Context

Restore loud failure for out-of-range values while keeping the `setBigDecimal` path for genuinely large UNSIGNED values that still fit the target.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

In-range UNSIGNED values keep full precision via `setBigDecimal`.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
