### PR TITLE
fix(lib-rdbms): preserve sub-second precision for time and timestamp targets

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
@@ -326,6 +326,9 @@ public class CommonRdbmsWriter
         /** Whether to treat empty strings as NULL values */
         protected boolean emptyAsNull;
 
+        /** logs the sub-second truncation fallback only once per task */
+        private boolean subsecondFallbackWarned;
+
         /** Metadata information about target table columns */
         protected List<Map<String, Object>> resultSetMetaData;
 
@@ -751,15 +754,19 @@ public class CommonRdbmsWriter
                     if (null != utilDate) {
                         sqlTime = new java.sql.Time(utilDate.getTime());
                         // preserve nanosecond precision if the source DateColumn carries it
-                        if (column instanceof DateColumn) {
-                            long nanos = ((DateColumn) column).getNanos();
-                            if (nanos > 0) {
-                                try {
-                                    preparedStatement.setObject(columnIndex,
-                                            sqlTime.toLocalTime().withNano((int) nanos));
-                                    break;
-                                } catch (SQLException ignored) {
-                                    // driver doesn't support LocalTime; fall through to setTime
+                        if (column instanceof DateColumn dateColumn && dateColumn.getNanos() > 0) {
+                            try {
+                                preparedStatement.setObject(columnIndex,
+                                        sqlTime.toLocalTime().withNano((int) dateColumn.getNanos()));
+                                break;
+                            }
+                            catch (SQLException | AbstractMethodError e) {
+                                // the driver cannot bind LocalTime; the setTime fallback below
+                                // truncates sub-second digits, so report that loss once per task
+                                if (!subsecondFallbackWarned) {
+                                    subsecondFallbackWarned = true;
+                                    LOG.warn("The JDBC driver cannot bind java.time.LocalTime; "
+                                            + "sub-second digits of TIME values will be truncated: {}", e.getMessage());
                                 }
                             }
                         }
@@ -768,7 +775,16 @@ public class CommonRdbmsWriter
                     break;
 
                 case Types.TIMESTAMP:
-                    preparedStatement.setTimestamp(columnIndex, column.asTimestamp());
+                    java.sql.Timestamp timestamp = column.asTimestamp();
+                    if (timestamp != null && column instanceof DateColumn dateColumn && dateColumn.getNanos() > 0) {
+                        // a DateColumn produced from a TIME(n) value carries sub-second precision
+                        // that the millisecond-based asTimestamp() would drop; rebuild it from the
+                        // whole seconds plus the carried nanos
+                        long secondBoundary = timestamp.getTime() - Math.floorMod(timestamp.getTime(), 1000);
+                        timestamp = new java.sql.Timestamp(secondBoundary);
+                        timestamp.setNanos((int) dateColumn.getNanos());
+                    }
+                    preparedStatement.setTimestamp(columnIndex, timestamp);
                     break;
 
                 case Types.BINARY:


### PR DESCRIPTION
## Summary

Writing a TIME(n) value to a TIME column silently swallowed bind failures (`catch (SQLException ignored)`) and fell back to millisecond `setTime`, and the same value written to a TIMESTAMP column lost its sub-second digits because `DateColumn.asTimestamp()` is millisecond-based.

## What type of change is this?
- [x] Bugfix

## Changes

- TIME target: bind `java.time.LocalTime` when the driver supports it; otherwise log the truncation fallback once per task instead of swallowing the error.
- TIMESTAMP target: rebuild the timestamp from the whole seconds plus the nanos carried by the `DateColumn`.

## Motivation and Context

TIME(6) sub-second digits disappeared silently on both targets.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

TIMESTAMP columns read as `TimestampColumn` already keep driver nanos and are untouched.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
