### PR TITLE
fix(lib-rdbms): detect tdengine by driver metadata, not class-name equality

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/util/DBUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/util/DBUtil.java
@@ -471,8 +471,8 @@ public final class DBUtil
         try (var statement = conn.createStatement()) {
             // Build query SQL based on database type
             String queryColumnSql;
-            if (DataBaseType.TDengine.getDriverClassName().equals(conn.getMetaData().getDriverName())) {
-                // TDengine does not support "1=2" clause
+            if (isTdengineConnection(conn)) {
+                // TDengine does not support the "1=2" clause
                 queryColumnSql = "SELECT " + column + " FROM " + tableName + " LIMIT 0";
             }
             else {
@@ -661,6 +661,24 @@ public final class DBUtil
     {
         SQLStatementParser statementParser = SQLParserUtils.createSQLStatementParser(sql, dataBaseType.getTypeName());
         statementParser.parseStatementList();
+    }
+
+    /**
+     * Whether the given connection is served by a TDengine driver.
+     * getDriverName() reports a display name such as "TSDB JDBC Driver", not the class
+     * name, so detection also covers the class names of the native and RESTful taos
+     * drivers and the connection implementation class.
+     */
+    private static boolean isTdengineConnection(Connection conn)
+            throws SQLException
+    {
+        String driverName = conn.getMetaData().getDriverName();
+        String driverNameLower = driverName == null ? "" : driverName.toLowerCase();
+        return "com.taosdata.jdbc.TSDBDriver".equals(driverName)
+                || "com.taosdata.jdbc.rs.RestfulDriver".equals(driverName)
+                || driverNameLower.contains("taos")
+                || driverNameLower.contains("tdengine")
+                || conn.getClass().getName().startsWith("com.taosdata");
     }
 
     /**


### PR DESCRIPTION
## Summary

`getColumnMetaData` compared the configured driver class name (`com.taosdata.jdbc.TSDBDriver`) with `getMetaData().getDriverName()`, which reports a display name such as `TSDB JDBC Driver`. The comparison was never true, so the `LIMIT 0` branch for TDengine was dead code and TDengine metadata queries always ran the `WHERE 1 = 2` path that TDengine cannot execute.

## What type of change is this?
- [x] Bugfix

## Changes

- Recognize taos connections by the driver/connection class names of the native and RESTful TDengine drivers (`com.taosdata.*`) as well as `TSDB`/`taos` name substrings.

## Motivation and Context

TDengine readers/writers could not obtain table column metadata.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

None.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
