### PR TITLE
refactor(lib-rdbms): scope writer task and pretreatment state per instance

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/CommonRdbmsWriter.java
@@ -79,7 +79,6 @@ public class CommonRdbmsWriter
         public Job(DataBaseType dataBaseType)
         {
             this.dataBaseType = dataBaseType;
-            OriginalConfPretreatmentUtil.dataBaseType = this.dataBaseType;
         }
 
         /**
@@ -276,10 +275,10 @@ public class CommonRdbmsWriter
         private static final String VALUE_HOLDER = "?";
 
         /** Basic message template for logging context information */
-        protected static String basicMessage;
+        protected String basicMessage;
 
         /** Template for INSERT/REPLACE SQL statements */
-        protected static String insertOrReplaceTemplate;
+        protected String insertOrReplaceTemplate;
 
         /** Database type for this task */
         protected DataBaseType dataBaseType;

--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/OriginalConfPretreatmentUtil.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/writer/util/OriginalConfPretreatmentUtil.java
@@ -48,9 +48,6 @@ import static com.wgzhao.addax.core.spi.ErrorCode.REQUIRED_VALUE;
 public final class OriginalConfPretreatmentUtil
 {
     private static final Logger LOG = LoggerFactory.getLogger(OriginalConfPretreatmentUtil.class);
-    // The database type used for processing configurations
-    /** The Databasetype. */
-    public static DataBaseType dataBaseType;
     private static final String jdbcUrlPath = Key.CONNECTION + "." + Key.JDBC_URL;
 
     private OriginalConfPretreatmentUtil()
@@ -78,8 +75,8 @@ public final class OriginalConfPretreatmentUtil
         }
 
         doCheckBatchSize(originalConfig);
-        simplifyConf(originalConfig);
-        dealColumnConf(originalConfig);
+        simplifyConf(originalConfig, dataBaseType);
+        dealColumnConf(originalConfig, dataBaseType);
         dealWriteMode(originalConfig, dataBaseType);
     }
 
@@ -104,8 +101,9 @@ public final class OriginalConfPretreatmentUtil
      * Processes JDBC URL, driver settings, and table expansion.
      *
      * @param originalConfig The configuration to simplify
+     * @param dataBaseType the database type, passed in instead of being shared statically
      */
-    public static void simplifyConf(Configuration originalConfig)
+    public static void simplifyConf(Configuration originalConfig, DataBaseType dataBaseType)
     {
         Configuration connConf = originalConfig.getConfiguration(Key.CONNECTION);
 
@@ -144,8 +142,9 @@ public final class OriginalConfPretreatmentUtil
      * Handles column expansion, validation against table schema, and duplicate checking.
      *
      * @param originalConfig The configuration containing column settings
+     * @param dataBaseType the database type for column quoting
      */
-    public static void dealColumnConf(Configuration originalConfig)
+    public static void dealColumnConf(Configuration originalConfig, DataBaseType dataBaseType)
     {
         String jdbcUrl = originalConfig.getString(jdbcUrlPath);
         String username = originalConfig.getString(Key.USERNAME);


### PR DESCRIPTION
## Summary

`Task` kept `insertOrReplaceTemplate` and `basicMessage` as `protected static` fields that concurrent writer tasks of one job overwrite, so a task could format its SQL with another task's template. The writer pretreatment utility shared one public static `DataBaseType` field that every `Job` constructor overwrote, corrupting concurrent jobs in the same JVM (server mode).

## What type of change is this?
- [x] Chore / Refactor

## Changes

- Turn the two task fields into instance fields.
- Pass `dataBaseType` as a method parameter through `doPretreatment`, `simplifyConf` and `dealColumnConf` instead of a shared static.

## Motivation and Context

Concurrent channels and jobs observed each other's templates and database type.

## How has this been tested?

`mvn -o -pl :addax-rdbms -DskipTests compile` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

Known limitation kept: the explicit `jdbcDriver` override still mutates the shared `DataBaseType` enum entry; removing it needs config plumbing through DBUtil call sites and is left for a follow-up.

## Additional context

Merge order note: branches touching `SingleTableSplitUtil.java` (#1-#4, #16), `CommonRdbmsWriter.java` (#8-#11, #15, #16) and `DBUtil.java` (#12-#13, #16) are independent on master but may need trivial manual resolution when merged sequentially.
