### PR TITLE
fix(lib-rdbms): probe localtime support instead of trusting time scale metadata

### DIFF
--- a/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/CommonRdbmsReader.java
+++ b/lib/addax-rdbms/src/main/java/com/wgzhao/addax/rdbms/reader/CommonRdbmsReader.java
@@ -188,6 +188,11 @@ public class CommonRdbmsReader
         // per-column metadata of the ResultSet currently being read; all values are
         // row-invariant and are materialized once per ResultSet instead of per row
         private ResultSetMetaData cachedMetaData;
+
+        // TIME(6) sub-second read state: once the driver fails to return LocalTime,
+        // stop probing it on later rows and warn about the lost precision once
+        private boolean localTimeProbeFailed;
+        private boolean localTimeFallbackWarned;
         private int[] cachedColTypes;
         private boolean[] cachedSigned;
         private int[] cachedScales;
@@ -390,12 +395,13 @@ public class CommonRdbmsReader
                 case Types.REAL:
                 case Types.DOUBLE:
                     return new DoubleColumn(rs.getString(i));
-                case Types.TIME:
+                case Types.TIME: {
                     java.sql.Time time = rs.getTime(i);
                     int nanos = 0;
-                    // ask the driver for the sub-second component only when the column
-                    // actually declares fractional digits, avoiding a second fetch per row
-                    if (cachedScales[i] > 0) {
+                    // some drivers (MySQL Connector/J) report scale 0 for TIME(6) columns, so the
+                    // fractional digits cannot be detected from metadata; probe LocalTime per cell
+                    // and stop probing only after the driver proved it cannot return one
+                    if (!localTimeProbeFailed) {
                         try {
                             java.time.LocalTime lt = rs.getObject(i, java.time.LocalTime.class);
                             if (lt != null) {
@@ -403,11 +409,18 @@ public class CommonRdbmsReader
                             }
                         }
                         catch (SQLException | AbstractMethodError | RuntimeException e) {
-                            // driver cannot return LocalTime for this column; millis-only value
-                            LOG.debug("Failed to read LocalTime of column {}: {}", i, e.getMessage());
+                            // driver cannot return LocalTime for TIME columns; keep the millisecond
+                            // value from now on and report the lost precision once per task
+                            localTimeProbeFailed = true;
+                            if (!localTimeFallbackWarned) {
+                                localTimeFallbackWarned = true;
+                                LOG.warn("The JDBC driver cannot return java.time.LocalTime for TIME columns; "
+                                        + "sub-second digits will be lost: {}", e.getMessage());
+                            }
                         }
                     }
                     return new DateColumn(time, nanos, cachedScales[i]);
+                }
                 case Types.DATE:
                     return new DateColumn(rs.getDate(i));
                 case Types.TIMESTAMP:


### PR DESCRIPTION
## Summary

The metadata-caching change in #1505 gated the sub-second `LocalTime` probe on `getScale() > 0`. MySQL Connector/J reports scale `0` for `TIME(6)` columns, so TIME sub-second digits were silently dropped on every MySQL read — a regression against the previous unconditional probe (found by end-to-end testing against MySQL 8.4, `TIME(6)` column read-write round trip).

## What type of change is this?
- [x] Bugfix

## Changes

- `CommonRdbmsReader.Task`: attempt `rs.getObject(java.time.LocalTime.class)` for every TIME cell; once the driver fails, stop probing on later rows and warn about the lost precision once per task (two task-level flags).

## Motivation and Context

Fixes a regression introduced by #1505 where `TIME(6)` values were truncated to milliseconds (e.g. `10:00:00.123456` became `10:00:00.123000`).

## How has this been tested?

Verified locally against MySQL 8.4 (`TIME(6)`, `DATETIME(6)`, `TIMESTAMP(6)` round trips):

- `SELECT * FROM t_time6 EXCEPT SELECT * FROM t_time6_out` → 0 rows (all three columns byte-identical, including `00:00:00.000001`).
- `TIME(6)` value written into a `DATETIME(6)` target column keeps all six fractional digits.

Build: `mvn -o -pl :addax-rdbms -DskipTests package` (JDK 17) passes.

## Checklist (required)
- [x] I ran a local build and fixed any compilation issues.
- [ ] I have not added any secrets or credentials.

## Release notes

TIME(6) reads on MySQL keep their fractional-second digits again.
