### PR TITLE
fix(script): repair build-module.sh base paths and CLI options

### DIFF
--- a/build-module.sh
+++ b/build-module.sh
@@ -22,16 +22,17 @@
 
 set -e  # Exit on any error
 
-# Get project version
-version=$(head -n40 pom.xml | awk -F'[<>]' '/<version>/ {print $3; exit}')
-export MAVEN_OPTS="-Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true "
+# gpg signing binds to the verify phase and needs a keyring; it only matters for
+# formal releases, so skip it for local installs
+export MAVEN_OPTS="-Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dgpg.skip=true "
 # if build for remote host, then skip all path exists check
 SKIP_CHECK=0
 
 function build_base() {
     echo "Building base components..."
     cd "$SRC_DIR"
-    mvn clean package -q -B -pl :addax-core,:addax-rdbms,:addax-storage -am || {
+    # install (not package) so downstream single-module builds resolve these SNAPSHOTs from the local repo
+    mvn clean install -q -B -pl :addax-core,:addax-rdbms,:addax-storage -am || {
         echo "Base build failed! Check dependencies and try again."
         exit 1
     }
@@ -39,14 +40,18 @@ function build_base() {
     # Ensure target directories exist
     mkdir -p "${ADDAX_HOME}/lib"
 
-    rsync -a core/target/addax-${version}/* "${ADDAX_HOME}"
-    rsync -azv lib/addax-{rdbms,storage}/target/addax-{rdbms,storage}-${version}/lib/* "${ADDAX_HOME}/lib/"
+    # assembly output dir is named after the artifactId (addax-core-<version>)
+    rsync -a core/target/addax-core-${version}/* "${ADDAX_HOME}"
+    # list source paths explicitly: two brace groups would expand to a cross product
+    rsync -azv lib/addax-rdbms/target/addax-rdbms-${version}/lib/* \
+        lib/addax-storage/target/addax-storage-${version}/lib/* "${ADDAX_HOME}/lib/"
     echo "Base build completed successfully"
 }
 
 # Set default directories if not provided
 if [ -z "$SRC_DIR" ]; then
-  SRC_DIR=$HOME/code/personal/Addax
+  # resolve the script's own location so any clone of the repo works out of the box
+  SRC_DIR=$(cd "$(dirname "$0")" && pwd)
   echo "Using default source directory: $SRC_DIR"
 fi
 
@@ -55,24 +60,38 @@ if [ -z "$ADDAX_HOME" ]; then
    echo "Using default Addax home: $ADDAX_HOME"
 fi
 
-# Check if we have any arguments
-if [ $# -eq 0 ]; then
-    echo "Usage: $0 module_name1 [module_name2 ...] [s]"
-    echo "       module_names: One or more module names to build"
-    echo "       s: Optional flag to sync only the jar file instead of the whole directory"
+# Get project version; the root pom has no <parent>, so the first <version> is ours.
+# Resolve against SRC_DIR so the script also works when invoked from any directory.
+version=$(awk -F'[<>]' '/<version>/ {print $3; exit}' "$SRC_DIR/pom.xml")
+if [ -z "$version" ]; then
+    echo "Error: cannot determine project version from $SRC_DIR/pom.xml"
     exit 1
 fi
 
-# Check if last argument is 's' flag
+# Parse options and module names (options come first, modules after)
+usage() {
+    echo "Usage: $0 [-s] module_name1 [module_name2 ...]"
+    echo "  module_name: reader/writer plugin artifact id (e.g. streamreader, mysqlwriter),"
+    echo "               or addax-core | server | addax-rdbms | addax-storage"
+    echo "  -s:          sync only the module jar instead of the whole plugin directory"
+    echo "Env overrides: SRC_DIR, ADDAX_HOME, REMOTE_HOST"
+}
+
 SYNC_JAR_ONLY=false
-MODULES=()
-for arg in "$@"; do
-    if [ "$arg" = "s" ]; then
-        SYNC_JAR_ONLY=true
-    else
-        MODULES+=("$arg")
-    fi
+while getopts ":hs" opt; do
+    case "$opt" in
+        s) SYNC_JAR_ONLY=true ;;
+        h) usage; exit 0 ;;
+        *) echo "Error: unknown option -$OPTARG" >&2; usage; exit 1 ;;
+    esac
 done
+shift $((OPTIND - 1))
+MODULES=("$@")
+
+if [ ${#MODULES[@]} -eq 0 ]; then
+    usage
+    exit 1
+fi
 
 # Handle remote host case
 if [ -n "${REMOTE_HOST}" ]; then
@@ -100,9 +119,14 @@ build_module() {
 
     echo "Building module: $MODULE_NAME"
     cd "$SRC_DIR"
-    mvn clean package -B -q -pl :$MODULE_NAME -am || {
-        echo "Failed to build $MODULE_NAME"
-        return 1
+    # avoid -am on the happy path: it rebuilds every upstream module on each iteration.
+    # fall back to -am only when the module's SNAPSHOT deps are missing or stale.
+    mvn clean install -B -q -pl :$MODULE_NAME || {
+        echo "Direct build failed for $MODULE_NAME, retrying with upstream modules (-am)..."
+        mvn clean install -B -q -pl :$MODULE_NAME -am || {
+            echo "Failed to build $MODULE_NAME (rerun without -q to see the error)"
+            return 1
+        }
     }
 
     # Handle special modules
@@ -150,12 +174,18 @@ build_module() {
     # Deploy module
     if [ "$SYNC_JAR_ONLY" = true ]; then
         echo "Deploying only the jar file for $MODULE_NAME..."
+        if [ $SKIP_CHECK -eq 0 ]; then
+            # a stale jar of a previous version would land on the classpath next to the new one
+            find "$ADDAX_HOME/$MODULE_DIR/$MODULE_NAME" -maxdepth 1 \
+                -name "${MODULE_NAME}-*.jar" ! -name "${MODULE_NAME}-${version}.jar" -delete 2>/dev/null || true
+        fi
         rsync -avz $MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}/$MODULE_DIR/${MODULE_NAME}/${MODULE_NAME}-${version}.jar \
                 $ADDAX_HOME/$MODULE_DIR/${MODULE_NAME}/
     else
         echo "Deploying complete module directory for $MODULE_NAME..."
-        rsync -avz --delete $MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}/$MODULE_DIR/${MODULE_NAME} \
-            $ADDAX_HOME/$MODULE_DIR/
+        # sync into the module's own dir so --delete never removes sibling plugins
+        rsync -avz --delete $MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}/$MODULE_DIR/${MODULE_NAME}/ \
+            $ADDAX_HOME/$MODULE_DIR/${MODULE_NAME}/
     fi
 
     echo "Module $MODULE_NAME deployed successfully"


### PR DESCRIPTION
## Summary

`build-module.sh` failed to initialize a fresh deployment: two broken rsync paths aborted the base setup with rsync exit 23, and the whole-directory plugin sync could wipe sibling plugins via `--delete`. This PR fixes those bugs and improves the script for everyday local developer use.

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [x] Chore / Refactor

## Changes

- Fix core assembly path in `build_base`: `addax-<version>` → `addax-core-<version>`
- Replace two brace groups in the rdbms/storage rsync source (they expand into a cross product producing nonexistent paths) with two explicit sources
- Scope the whole-directory sync `--delete` to the module's own directory so deployed sibling plugins are never removed
- Skip gpg signing for local installs (`-Dgpg.skip=true`): signing binds to the verify phase and fails without a keyring
- Build with `install` instead of `package`, and drop `-am` on the happy path of single-module builds (falling back to `-am` only when upstream SNAPSHOTs are missing or stale)
- Move the jar-only flag to a POSIX `-s` option parsed with `getopts` (options before module names); add `-h` help
- Delete stale plugin jars of previous versions before a jar-only sync
- Resolve `SRC_DIR` from the script location and project version against `SRC_DIR/pom.xml`, so the script works when invoked from any directory

## Motivation and Context

The script is the daily driver for local build-and-deploy during plugin development. Base initialization always failed on the broken rsync paths, so a first run on a new machine could never populate the deploy directory; the `--delete` bug could silently remove every other plugin in `plugin/reader` or `plugin/writer` on upgrade.

## How has this been tested?

- Fresh-machine path: removed the deployed `bin` directory, the script rebuilt the base components and populated the deploy directory end to end
- `./build-module.sh streamreader` (whole-directory sync): deployed correctly; a dummy sibling plugin stayed intact after the sync
- `./build-module.sh -s streamreader` (jar-only sync): a stale `streamreader-9.9.9.jar` was removed and the current version jar was kept
- Invoked from `/tmp` with an absolute script path (cwd-independent resolution)
- No-args usage, unknown option (`-x`), and `-h` exit codes verified

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

Fixes initialization and deployment of `build-module.sh` and adds a POSIX `-s` option for jar-only sync.
