### PR TITLE
fix(lib-storage): repair writeToSql batch flush truncation and restore column-count guard

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -528,6 +528,8 @@ public final class StorageWriterUtil
 
         Record record;
         while ((record = lineReceiver.getFromReader()) != null) {
+            validateRecordColumns(record, columns);
+
             appendRecordValues(record, sb);
 
             if (!extendedInsert) {

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -530,27 +530,34 @@ public final class StorageWriterUtil
         while ((record = lineReceiver.getFromReader()) != null) {
             appendRecordValues(record, sb);
 
-            if (extendedInsert) {
-                currentBatchSize++;
-                if (currentBatchSize >= batchSize) {
-                    writeAndResetBuffer(writer, sb, sqlHeader);
-                    currentBatchSize = 0;
-                }
-                else {
-                    sb.append("), (");
-                }
-            }
-            else {
+            if (!extendedInsert) {
+                // one INSERT statement per record
                 sb.append(");\n");
                 writer.write(sb.toString());
                 sb.setLength(0);
                 sb.append(sqlHeader).append(" VALUES (");
+                continue;
+            }
+
+            currentBatchSize++;
+            if (currentBatchSize < batchSize) {
+                // join the next record to the current statement
+                sb.append("), (");
+            }
+            else {
+                // batch is full: the buffer ends with the bare row values (no separator yet),
+                // so close the statement explicitly instead of stripping a trailing separator
+                sb.append(");\n");
+                writer.write(sb.toString());
+                sb.setLength(0);
+                sb.append(sqlHeader).append(" VALUES (");
+                currentBatchSize = 0;
             }
         }
 
-        // Write remaining records
+        // A partial trailing batch ends with the "), (" separator appended above: strip it and close
         if (currentBatchSize > 0) {
-            sb.delete(sb.length() - 3, sb.length()).append(";\n");
+            sb.delete(sb.length() - 4, sb.length()).append(");\n");
             writer.write(sb.toString());
         }
     }
@@ -618,20 +625,4 @@ public final class StorageWriterUtil
         }
     }
 
-    /**
-     * Write buffer content and reset for next batch.
-     *
-     * @param writer the writer to write to
-     * @param sb the StringBuilder to write and reset
-     * @param sqlHeader SQL header for next batch
-     * @throws IOException if writing fails
-     */
-    private static void writeAndResetBuffer(BufferedWriter writer, StringBuilder sb, String sqlHeader)
-            throws IOException
-    {
-        sb.delete(sb.length() - 3, sb.length()).append(";\n");
-        writer.write(sb.toString());
-        sb.setLength(0);
-        sb.append(sqlHeader).append(" VALUES (");
-    }
 }


### PR DESCRIPTION
## Summary

Fixes two defects in the `writeToSql` extended-insert path of `StorageWriterUtil` (used by `txtfilewriter`/`ftpwriter`/etc. with `fileFormat=sql`):

1. **Batch flush truncates the last row of every full batch.** `writeAndResetBuffer` unconditionally deleted the trailing 3 characters of the buffer, assuming the tail was the `"), ("` row separator. But a flush is triggered right after the completing record is appended *bare* (the separator is only appended in the else-branch), so the deletion ate the last 3 characters of that record's value text and left the tuple unclosed — every flushed statement was corrupt SQL with the last row damaged or lost (with the default `batchSize=2048`, every export with ≥ 2048 rows).
2. **Per-record column-count validation was silently dropped** in refactor `e3a13908d` (the call site was removed, leaving `validateRecordColumns` dead). Mismatched record/column arity now flows into misaligned `INSERT` text instead of failing with `CONFIG_ERROR`.

## What type of change is this?
- [x] Bugfix

## Changes

Commit 1 — restructure the extended-insert loop:
- Each statement is now closed explicitly (`");\n"`) when the batch fills; `"), ("` is only used between rows; no position-based tail surgery anywhere in the loop.
- The end-of-stream flush strips the trailing separator under a now-guaranteed invariant (it is only present when a partial batch is pending) — byte-identical output to the previously working case.
- `writeAndResetBuffer` (the source of the tail-assumption bug) is removed.

Commit 2 — restore `validateRecordColumns(record, columns)` as the first step of the per-record loop, matching the pre-refactor behavior.

## Motivation and Context

Verified by executing the exact loop logic: with `batchSize=2` and two rows, the old code emitted `INSERT INTO t(a) VALUES (1),;` — the second row destroyed. Reported against `lib/addax-storage` by a module code review.

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace: full-batch, partial-trailing, exact-multiple, `extendedInsert=false`, and `batchSize=1` cases all close statements with `");\n"` and keep every row.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a, no behavior/API surface change
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
