### PR TITLE
fix(lib-storage): emit SQL NULL instead of the quoted literal 'null'

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -599,17 +599,17 @@ public final class StorageWriterUtil
         for (int i = 0; i < record.getColumnNumber(); i++) {
             Column column = record.getColumn(i);
 
+            // A null column (or null raw data) must become SQL NULL, never the quoted literal 'null'
+            if (column == null || column.getRawData() == null) {
+                sb.append("NULL");
+            }
             // Numeric and boolean columns don't need quotes
-            if (column instanceof LongColumn || column instanceof BoolColumn) {
+            else if (column instanceof LongColumn || column instanceof BoolColumn) {
                 sb.append(column.asString());
             }
             else {
                 // Escape single quotes in string values
-                String value = column.asString();
-                if (value != null) {
-                    value = value.replace("'", "''");
-                }
-                sb.append("'").append(value).append("'");
+                sb.append("'").append(column.asString().replace("'", "''")).append("'");
             }
 
             if (i < record.getColumnNumber() - 1) {


### PR DESCRIPTION
## Summary

In `StorageWriterUtil.appendRecordValues` (the `fileFormat=sql` export path used by `txtfilewriter`/`ftpwriter`), a null column was rendered as the quoted string literal `'null'` instead of SQL `NULL`:

- String/Date/Timestamp/Double columns with null raw data went through the quoted branch, where `StringBuilder.append((String) null)` prints the text `"null"` between single quotes — e.g. `INSERT INTO t(name) VALUES ('null')`.
- Importing such a dump silently stores the string `'null'` in nullable columns (indistinguishable from real data afterwards), or fails on typed/numeric/date columns in strict databases.
- Null `LongColumn`/`BoolColumn` values only worked *by accident* because their branch is unquoted (a bare `null` token is the SQL keyword).

## What type of change is this?
- [x] Bugfix

## Changes

- When `column == null` or `column.getRawData() == null`, append the bare `NULL` keyword and skip quoting.
- Kept the single-quote escaping and the comma placement unchanged for all non-null rows.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review: the SQL writer never consults `nullFormat`, so `'null'` text was the only possible rendering of a null column.

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace of null and non-null values of each column kind.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
