### PR TITLE
fix(lib-storage): guard null fields in the untyped column branch

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -299,7 +299,9 @@ public final class StorageReaderUtil
             // No column configuration - treat all as strings
             for (String columnValue : sourceLine) {
                 // Note: not equalsIgnoreCase, it's all ok if nullFormat is null
-                Column columnGenerated = columnValue.equals(nullFormat)
+                // commons-csv yields null for a field matching nullFormat, so check null first,
+                // mirroring the guard the typed branch has in createTypedColumn
+                Column columnGenerated = (columnValue == null || columnValue.equals(nullFormat))
                     ? new StringColumn(null)
                     : new StringColumn(columnValue);
                 record.addColumn(columnGenerated);


### PR DESCRIPTION
## Summary

`StorageReaderUtil.transportOneRecord`'s no-column-config branch (used when no `column` list is configured or `["*"]` selects all-strings mode) crashed with a `NullPointerException` whenever a `nullFormat` was configured and a field matched it.

Commons-csv pre-converts fields matching `nullString` to Java `null`, so `columnValue.equals(nullFormat)` was invoked on `null` — outside the per-record try/catch that routes failures to the dirty collector — and the whole file read aborted with an opaque runtime error at the first null marker. The typed branch (`createTypedColumn`) already guards `columnValue == null` first; the untyped branch did not.

## What type of change is this?
- [x] Bugfix

## Changes

- In the untyped branch, a `null` field is now treated the same as a `nullFormat` match and emitted as a `StringColumn` with null raw data (a null column), mirroring the typed branch.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review and verified against commons-csv 1.14.1 behavior (`setNullString` → parser yields null elements).

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace with `column: ["*"]` / no column list + `nullFormat` and a matching field.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
