### PR TITLE
fix(lib-storage): accept gzip/bz2 aliases on read and case-fold compress names safely

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -62,6 +62,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
@@ -172,7 +173,15 @@ public final class StorageReaderUtil
             return new BufferedReader(new InputStreamReader(inputStream, encoding), bufferSize);
         }
 
-        return switch (compress.toLowerCase()) {
+        // Normalize to the spellings commons-compress accepts, mirroring StorageWriterUtil.createWriter,
+        // so a compress value written by the writer side (gzip/bz2) also reads back on this side
+        String normalizedCompress = switch (compress.toLowerCase(Locale.ROOT)) {
+            case "gzip" -> "gz";
+            case "bz2" -> "bzip2";
+            default -> compress.toLowerCase(Locale.ROOT);
+        };
+
+        return switch (normalizedCompress) {
             case COMPRESS_ZIP -> {
                 ZipCycleInputStream zipCycleInputStream = new ZipCycleInputStream(inputStream);
                 yield new BufferedReader(new InputStreamReader(zipCycleInputStream, encoding), bufferSize);
@@ -184,7 +193,7 @@ public final class StorageReaderUtil
             default -> {
                 // Apache Commons Compress supports most compression algorithms
                 CompressorInputStream input = new CompressorStreamFactory().createCompressorInputStream(
-                        compress.toUpperCase(), inputStream, true);
+                        normalizedCompress, inputStream, true);
                 yield new BufferedReader(new InputStreamReader(input, encoding), bufferSize);
             }
         };

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -172,7 +173,8 @@ public final class FileHelper
         if (StringUtils.isBlank(compress) || "none".equalsIgnoreCase(compress)) {
             return "";
         }
-        String suffix = COMPRESS_TYPE_SUFFIX_MAP.getOrDefault(compress.toUpperCase(), "." + compress.toLowerCase());
+        String suffix = COMPRESS_TYPE_SUFFIX_MAP.getOrDefault(compress.toUpperCase(Locale.ROOT),
+                "." + compress.toLowerCase(Locale.ROOT));
         LOG.debug("Compression type '{}' maps to suffix '{}'", compress, suffix);
         return suffix;
     }

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -55,6 +55,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -361,11 +362,12 @@ public final class StorageWriterUtil
             return new BufferedWriter(new OutputStreamWriter(outputStream, encoding));
         }
 
-        // Normalize compress name for compatibility
-        String normalizedCompress = switch (compress.toLowerCase()) {
+        // Normalize compress name for compatibility; Locale.ROOT keeps locale-sensitive JVMs
+        // (e.g. tr_TR) from mangling ASCII names such as "ZIP" -> "zıp"
+        String normalizedCompress = switch (compress.toLowerCase(Locale.ROOT)) {
             case "gzip" -> "gz";
             case "bz2" -> "bzip2";
-            default -> compress.toLowerCase();
+            default -> compress.toLowerCase(Locale.ROOT);
         };
 
         if ("zip".equals(normalizedCompress)) {


### PR DESCRIPTION
## Summary

Two compression-handling asymmetries in the storage module, both affecting which `compress` spellings work and whether case conversion is locale-safe:

1. **Reader cannot accept the aliases the writer produces.** `StorageWriterUtil.createWriter` normalizes `gzip → gz` and `bz2 → bzip2`, but `StorageReaderUtil.createBufferedReader` uppercased the raw config value and handed it to `CompressorStreamFactory`, which only knows canonical names (`gz`, `bzip2`, …). A `compress: "gzip"` job written by the writer could never be read back on the read side.
2. **Locale-sensitive case folding.** `toLowerCase()`/`toUpperCase()` without a locale mangle ASCII names on e.g. `tr_TR` JVMs (`"ZIP".toLowerCase()` → `"zıp"`), silently breaking the `zip` dispatch, the factory call, and the suffix map lookup in `FileHelper.getCompressFileSuffix`.

## What type of change is this?
- [x] Bugfix

## Changes

- `createBufferedReader`: normalize `gzip → gz`, `bz2 → bzip2` (mirroring `createWriter`), then dispatch on the canonical lowercase name and pass it directly to `CompressorStreamFactory` (zip/lzo still handled by the module's own streams).
- `createWriter` and `FileHelper.getCompressFileSuffix`: all compress-name case conversions now use `Locale.ROOT`.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review; verified empirically against commons-compress 1.27.1 (the pinned version), which throws `Compressor: ... not found` for `gzip`/`bz2`/`GZIP`/`BZ2` spellings.

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace: `gz`, `gzip`, `GZIP`, `bz2`, `bzip2`, `zip`, `lzo`, `xz`, `zstd` on the read path; `-Duser.language=tr -Duser.country=TR` casing behavior.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
