### PR TITLE
fix(lib-storage): keep empty fields when splitting per-line records

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -276,9 +276,28 @@ public final class StorageReaderUtil
         // Note: default value is ',', fieldDelimiter could be \n(lineDelimiter) for no fieldDelimiter
         Character fieldDelimiter = configuration.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
 
-        String[] sourceLine = StringUtils.split(line, fieldDelimiter);
+        String[] sourceLine = splitPreservingEmptyFields(line, fieldDelimiter);
 
         transportOneRecord(recordSender, column, sourceLine, nullFormat, taskPluginCollector);
+    }
+
+    /**
+     * Split a single line by a delimiter character, keeping every token including empty
+     * and trailing-empty ones. StringUtils.split collapses empty tokens, which shifts
+     * column indexes; the commons-csv parsing used by {@link #doReadFromStream} keeps them,
+     * so the per-line path must behave the same way.
+     */
+    private static String[] splitPreservingEmptyFields(String line, char delimiter)
+    {
+        List<String> fields = new ArrayList<>();
+        int start = 0;
+        int index;
+        while ((index = line.indexOf(delimiter, start)) != -1) {
+            fields.add(line.substring(start, index));
+            start = index + 1;
+        }
+        fields.add(line.substring(start));
+        return fields.toArray(new String[0]);
     }
 
     /**


### PR DESCRIPTION
## Summary

The per-line `transportOneRecord(RecordSender, Configuration, TaskPluginCollector, String)` overload (the hdfsreader **sequence-file** path, invoked once per record from `DFSUtil.sequenceFileStartRead`) split record lines with `StringUtils.split`, which **drops empty tokens and trailing empties**.

A Hive/sequence-file row with an empty column (e.g. `a,,b`) was split to `[a, b]`, shifting every subsequent column against the configured index/type mapping — values landed in the wrong typed column or the row was thrown away as dirty with an `IndexOutOfBoundsException`. The same content read through the commons-csv path (`doReadFromStream`, `fileType=text`) keeps the empty fields, so behavior was inconsistent by file type and data was silently corrupted on the seq path.

## What type of change is this?
- [x] Bugfix

## Changes

- Replaced `StringUtils.split(line, fieldDelimiter)` with a small `indexOf`-based splitter that keeps every token, including empty and trailing-empty ones — the same semantics commons-csv produces on the `doReadFromStream` path.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review (cross-file contract tracer verified the divergence between the seq per-line path and the commons-csv path).

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace: `"a,,b"` → 3 tokens, `"a,b,"` → 3 tokens, no-delimiter line → 1 token.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
