### PR TITLE
refactor(lib-storage): delete dead helper and narrow the public API surface

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -324,8 +324,8 @@ public final class StorageReaderUtil
             taskPluginCollector.collectDirtyRecord(record, iae.getMessage());
         }
         catch (Exception e) {
-            if (e instanceof AddaxException) {
-                throw (AddaxException) e;
+            if (e instanceof AddaxException addaxException) {
+                throw addaxException;
             }
             // Each record which transfer failed should be regarded as dirty
             taskPluginCollector.collectDirtyRecord(record, e.getMessage());

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -46,7 +46,6 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.io.Charsets;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -199,7 +198,7 @@ public final class StorageReaderUtil
      * @param recordSender sender for processed records
      * @param taskPluginCollector collector for error handling
      */
-    public static void doReadFromStream(BufferedReader reader, String fileName,
+    private static void doReadFromStream(BufferedReader reader, String fileName,
             Configuration readerSliceConfig, RecordSender recordSender,
             TaskPluginCollector taskPluginCollector)
     {
@@ -462,7 +461,7 @@ public final class StorageReaderUtil
      * @param readerConfiguration configuration to validate
      * @throws AddaxException if encoding is not supported
      */
-    public static void validateEncoding(Configuration readerConfiguration)
+    private static void validateEncoding(Configuration readerConfiguration)
     {
         // Encoding check
         String encoding = readerConfiguration.getString(Key.ENCODING, Constant.DEFAULT_ENCODING);
@@ -487,7 +486,7 @@ public final class StorageReaderUtil
      * @param readerConfiguration configuration to validate
      * @throws AddaxException if delimiter is invalid
      */
-    public static void validateFieldDelimiter(Configuration readerConfiguration)
+    private static void validateFieldDelimiter(Configuration readerConfiguration)
     {
         // Field delimiter check
         String delimiterInStr = readerConfiguration.getString(Key.FIELD_DELIMITER, ",");
@@ -506,7 +505,7 @@ public final class StorageReaderUtil
      *
      * @param readerConfiguration configuration to validate
      */
-    public static void validateColumn(Configuration readerConfiguration)
+    private static void validateColumn(Configuration readerConfiguration)
     {
         // Column validation: 1. index type 2. value type 3. when type is Date, may have format
         List<Configuration> columns = readerConfiguration.getListConfiguration(Key.COLUMN);
@@ -545,22 +544,4 @@ public final class StorageReaderUtil
         }
     }
 
-    /**
-     * Get the parent path of a path with wildcard, only the last level.
-     *
-     * @param regexPath path with potential wildcards
-     * @return parent path without wildcards
-     */
-    public static String getRegexPathParentPath(String regexPath)
-    {
-        int lastDirSeparator = regexPath.lastIndexOf(IOUtils.DIR_SEPARATOR);
-        String parentPath = regexPath.substring(0, lastDirSeparator + 1);
-
-        if (parentPath.contains("*") || parentPath.contains("?")) {
-            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                    String.format("The path '%s' is illegal, ONLY the trail folder can contain wildcard * or ?",
-                            regexPath));
-        }
-        return parentPath;
-    }
 }

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -458,7 +458,7 @@ public final class StorageWriterUtil
      * @param taskPluginCollector collector for error handling
      * @return list of string values, or null if conversion fails
      */
-    public static List<String> recordToList(Record record, String nullFormat, DateFormat dateParse, TaskPluginCollector taskPluginCollector)
+    private static List<String> recordToList(Record record, String nullFormat, DateFormat dateParse, TaskPluginCollector taskPluginCollector)
     {
         try {
             List<String> splitRows = new ArrayList<>();
@@ -514,7 +514,7 @@ public final class StorageWriterUtil
      * @throws IOException if writing fails
      * @throws AddaxException if configuration is invalid
      */
-    public static void writeToSql(RecordReceiver lineReceiver, BufferedWriter writer, Configuration config)
+    private static void writeToSql(RecordReceiver lineReceiver, BufferedWriter writer, Configuration config)
             throws IOException
     {
         String tableName = config.getNecessaryValue(Key.TABLE, REQUIRED_VALUE);


### PR DESCRIPTION
## Summary

API-surface cleanup of the two storage utility classes (from a module code review):

- `StorageReaderUtil.getRegexPathParentPath` is **dead** — zero callers repo-wide — and is removed (its `IOUtils` import went with it).
- Six helpers that are only ever invoked from within their own class were `public` on a shared library module: `doReadFromStream`, `validateEncoding`, `validateFieldDelimiter`, `validateColumn` (reader) and `writeToSql`, `recordToList` (writer). They are now `private`. This would have caught the recently-dropped `validateRecordColumns` call site (compile error) instead of leaving a silently dead guard.
- `transportOneRecord`'s catch handler now uses an `instanceof` pattern variable instead of a manual cast (JDK 17).

## What type of change is this?
- [x] Chore / Refactor

## Changes

Commit 1 — remove the dead helper and narrow visibility (verified with repo-wide greps: the only remaining external callers of `StorageReaderUtil`/`StorageWriterUtil` are `readFromStream`, `transportOneRecord` (both overloads), `getListColumnEntry`, `validateParameter`, `split`, `buildFilePath`, `writeToStream`, which all stay public).

Commit 2 — `instanceof AddaxException` → `instanceof AddaxException addaxException` pattern variable.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review (reuse/dead-code audit): over-exposed public API on a library module that ~13 file plugins compile against misleads fixers and hides dead code.

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Repo-wide grep confirmed zero external callers of every narrowed/deleted symbol before the change.
- No unit tests added; per project convention, verification happens in the build environment manually.

Note: out-of-tree consumers of these six methods (none in this repository) would need to stop calling them; the public entry points are unchanged.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, grep + compile verification
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
