### PR TITLE
refactor(lib-storage): decode local files with one open and single-source wildcard normalization

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -122,11 +122,8 @@ public final class StorageReaderUtil
             LOG.warn("The encoding: [{}] is illegal, uses [{}] by default", encoding, Constant.DEFAULT_ENCODING);
         }
 
-        List<Configuration> column = readerSliceConfig.getListConfiguration(Key.COLUMN);
-        // Handle ["*"] -> [], null
-        if (column != null && column.size() == 1 && "\"*\"".equals(column.get(0).toString())) {
-            readerSliceConfig.set(Key.COLUMN, null);
-        }
+        // Handle ["*"] (or ['*'] in YAML jobs) -> all columns as strings
+        normalizeWildcardColumn(readerSliceConfig);
 
         int bufferSize = readerSliceConfig.getInt(Key.BUFFER_SIZE, Constant.DEFAULT_BUFFER_SIZE);
 
@@ -445,6 +442,27 @@ public final class StorageReaderUtil
     }
 
     /**
+     * Normalize the ["*"] marker (all columns as strings) into a null column configuration.
+     * JSON serialization always quotes with double quotes, but YAML jobs may carry single quotes,
+     * so both spellings are matched here. Single-sourcing this keeps the two call sites consistent.
+     *
+     * @param configuration configuration holding the column list
+     * @return true if the wildcard marker was found and cleared
+     */
+    private static boolean normalizeWildcardColumn(Configuration configuration)
+    {
+        List<Configuration> columns = configuration.getListConfiguration(Key.COLUMN);
+        if (columns != null && columns.size() == 1) {
+            String columnInStr = columns.get(0).toString();
+            if ("\"*\"".equals(columnInStr) || "'*'".equals(columnInStr)) {
+                configuration.set(Key.COLUMN, null);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Validate reader configuration parameters including encoding, compression, and field delimiter.
      *
      * @param readerConfiguration the configuration to validate
@@ -514,13 +532,9 @@ public final class StorageReaderUtil
             throw AddaxException.missingConfig(Key.COLUMN);
         }
 
-        // Handle ["*"]
-        if (columns.size() == 1) {
-            String columnsInStr = columns.get(0).toString();
-            if ("\"*\"".equals(columnsInStr) || "'*'".equals(columnsInStr)) {
-                readerConfiguration.set(Key.COLUMN, null);
-                return;
-            }
+        // Handle ["*"] -> all columns as strings; nothing left to validate
+        if (normalizeWildcardColumn(readerConfiguration)) {
+            return;
         }
 
         for (Configuration eachColumnConf : columns) {

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
@@ -18,10 +18,12 @@
 
 package com.wgzhao.addax.storage.util;
 
+import com.wgzhao.addax.core.compress.ExpandLzopInputStream;
 import com.wgzhao.addax.core.compress.ZipCycleInputStream;
 import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.spi.ErrorCode;
 import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -30,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -45,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -97,42 +99,6 @@ public final class FileHelper
     }
 
     /**
-     * Detect the compression type of the specified file.
-     *
-     * @param fileName the file name to analyze
-     * @return the compression type if present, otherwise "none"
-     * @throws IOException if there's an error reading the file
-     */
-    public static String getFileCompressType(String fileName)
-            throws IOException
-    {
-        if (StringUtils.isBlank(fileName)) {
-            LOG.warn("Empty or null file name provided for compression detection");
-            return "none";
-        }
-
-        LOG.debug("Detecting compression type for file: {}", fileName);
-
-        Path filePath = Paths.get(fileName);
-        if (!Files.exists(filePath)) {
-            throw new FileNotFoundException("File not found: " + fileName);
-        }
-
-        if (!Files.isReadable(filePath)) {
-            throw new IOException("File is not readable: " + fileName);
-        }
-
-        try (InputStream inputStream = Files.newInputStream(filePath);
-             BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream)) {
-            return getFileCompressType(bufferedInputStream);
-        }
-        catch (IOException e) {
-            LOG.error("Failed to detect compression type for file: {}", fileName, e);
-            throw e;
-        }
-    }
-
-    /**
      * Detect compression type from an input stream.
      * The input stream must support mark/reset operations.
      *
@@ -140,7 +106,7 @@ public final class FileHelper
      * @return the compression type if present, otherwise "none"
      * @throws IllegalArgumentException if the input stream doesn't support mark
      */
-    public static String getFileCompressType(InputStream inputStream)
+    private static String getFileCompressType(InputStream inputStream)
     {
         if (inputStream == null) {
             throw new IllegalArgumentException("Input stream cannot be null");
@@ -178,7 +144,7 @@ public final class FileHelper
     }
 
     /**
-     * Read a compressed file and return a buffered reader.
+     * Read a (possibly compressed) file and return a buffered reader over its decoded content.
      *
      * @param fileName the file to read
      * @param encoding character encoding to use (if null, uses UTF-8)
@@ -199,26 +165,49 @@ public final class FileHelper
         LOG.debug("Reading compressed file: {} with encoding: {}, buffer size: {}",
                 fileName, actualEncoding, actualBufferSize);
 
+        Path path = Paths.get(fileName);
         try {
-            String compressType = getFileCompressType(fileName);
-            LOG.debug("Detected compression type: {} for file: {}", compressType, fileName);
-            Path path = Paths.get(fileName);
+            // Single open: magic detection and decoding share one buffered stream
+            BufferedInputStream bufferedInput = new BufferedInputStream(Files.newInputStream(path));
+            try {
+                // CompressorStreamFactory detects gz/bzip2/xz/... from magic bytes but has no zip/lzo
+                // provider, so fall back to the file suffix for those two addax-native formats
+                String compressType = getFileCompressType(bufferedInput);
+                if ("none".equals(compressType)) {
+                    String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
+                    if (lowerCaseName.endsWith(".zip")) {
+                        compressType = "zip";
+                    }
+                    else if (lowerCaseName.endsWith(".lzo") || lowerCaseName.endsWith(".lzop")) {
+                        compressType = "lzo";
+                    }
+                }
+                LOG.debug("Detected compression type: {} for file: {}", compressType, fileName);
 
-            return switch (compressType) {
-                case "none" -> Files.newBufferedReader(path, Charset.forName(actualEncoding));
-                case "zip" -> {
-                    InputStream inputStream = Files.newInputStream(path);
-                    ZipCycleInputStream zis = new ZipCycleInputStream(inputStream);
-                    yield new BufferedReader(new InputStreamReader(zis, actualEncoding), actualBufferSize);
-                }
-                default -> {
-                    InputStream inputStream = Files.newInputStream(path);
-                    BufferedInputStream bis = new BufferedInputStream(inputStream);
-                    InputStream compressedInput = new CompressorStreamFactory()
-                            .createCompressorInputStream(compressType, bis, true);
-                    yield new BufferedReader(new InputStreamReader(compressedInput, actualEncoding), actualBufferSize);
-                }
-            };
+                return switch (compressType) {
+                    case "none" -> new BufferedReader(
+                            new InputStreamReader(bufferedInput, Charset.forName(actualEncoding)), actualBufferSize);
+                    case "zip" -> {
+                        ZipCycleInputStream zis = new ZipCycleInputStream(bufferedInput);
+                        yield new BufferedReader(new InputStreamReader(zis, actualEncoding), actualBufferSize);
+                    }
+                    case "lzo" -> {
+                        ExpandLzopInputStream expandLzopInputStream = new ExpandLzopInputStream(bufferedInput);
+                        yield new BufferedReader(
+                                new InputStreamReader(expandLzopInputStream, actualEncoding), actualBufferSize);
+                    }
+                    default -> {
+                        CompressorInputStream input = new CompressorStreamFactory()
+                                .createCompressorInputStream(compressType, bufferedInput, true);
+                        yield new BufferedReader(new InputStreamReader(input, actualEncoding), actualBufferSize);
+                    }
+                };
+            }
+            catch (IOException | CompressorException e) {
+                // the returned reader chain owns bufferedInput only after a successful wrap
+                bufferedInput.close();
+                throw e;
+            }
         }
         catch (IOException | CompressorException e) {
             throw AddaxException.asAddaxException(


### PR DESCRIPTION
## Summary

Two consistency reworks in `lib/addax-storage`, both removing duplicated logic that had already drifted between its two homes:

**Commit 1 — decode local files with a single open, honor the buffer size, and make the zip/lzo branches reachable (`FileHelper.readCompressFile`, used by `TxtFileReader` header sniffing):**
- The file was opened twice: once by `getFileCompressType(String)` for magic detection (open + close), then again for reading — now one buffered stream is shared (mark/reset detection) and closed if wrapping fails.
- The plain-file branch used `Files.newBufferedReader` and silently ignored the requested `bufferSize` — now every branch honors it.
- `CompressorStreamFactory` has **no zip/lzo provider**, so magic detection could never return `"zip"`/`"lzo"`; the `zip` branch was dead code and zip files were decoded as raw text (garbage header → `ILLEGAL_VALUE` at column-name mapping). Detection now falls back to the `.zip`/`.lzo`/`.lzop` suffix only when magic says `none`.
- The now-unused `getFileCompressType(String)` overload is removed and `getFileCompressType(InputStream)` becomes private.

**Commit 2 — single-source wildcard column normalization (`StorageReaderUtil`):**
- The `["*"]` (all columns as strings) marker was normalized in `readFromStream` (double quotes only) and `validateColumn` (double *and* single quotes). Both now call one `normalizeWildcardColumn(Configuration)` that matches both quote styles.

## What type of change is this?
- [x] Chore / Refactor
- [x] Bugfix (commit 1 fixes zip/lzo header sniffing; commit 2 aligns YAML quoting behavior)

## Changes

- `FileHelper.readCompressFile`: single-open detection + decode; buffer size honored in all branches; extension fallback for zip/lzo; resource closed on wrap failure.
- `FileHelper`: remove `getFileCompressType(String)` (no callers after the rework), privatize `getFileCompressType(InputStream)`.
- `StorageReaderUtil`: new private `normalizeWildcardColumn` used by both `readFromStream` and `validateColumn`.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review: duplicated implementation with observable drift (buffer-size divergence between the plain-file branches, unreachable zip branch, mismatched quote handling for the `["*"]` marker).

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean (both commits).
- Manual trace: `.zip`, `.gz`, `.lzo`, plain and misnamed files through the new dispatch; `["*"]` and `['*']` configs through both entry points.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
