### PR TITLE
refactor(lib-storage): replace SimpleDateFormat with a shared immutable formatter

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/util/FileHelper.java
@@ -40,9 +40,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -385,12 +386,16 @@ public final class FileHelper
      *
      * @return generated string for file naming (never null)
      */
+    // Shared formatter: SimpleDateFormat is mutable and unsafe to share across the concurrent
+    // writer tasks that generate file names; java.time formatters are immutable and thread-safe
+    private static final DateTimeFormatter FILE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS").withZone(ZoneId.systemDefault());
+
     public static String generateFileMiddleName()
     {
         String randomChars = "0123456789abcdefghmnpqrstuvwxyz";
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS");
         // Generate format like: 20211203_143329_237_6587fddb
-        return dateFormat.format(new Date()) + "_" +
+        return FILE_TIME_FORMATTER.format(Instant.now()) + "_" +
                RandomStringUtils.insecure().next(8, randomChars);
     }
 }


### PR DESCRIPTION
## Summary

JDK 17 modernization of `FileHelper.generateFileMiddleName` (called on every split output-file name by `StorageWriterUtil.split`, `HdfsWriter` and `DbfWriter`): it constructed a **new `SimpleDateFormat` (plus a `Date`) on every call**, and the natural "optimization" of hoisting it to a static field would introduce the classic shared-mutable `SimpleDateFormat` race across the concurrent writer threads.

## What type of change is this?
- [x] Chore / Refactor

## Changes

- A `static final DateTimeFormatter` (`yyyyMMdd_HHmmss_SSS` in the system zone — the exact semantics of `SimpleDateFormat` on `Date`) now formats `Instant.now()`.
- Removed the `SimpleDateFormat`/`Date` imports.

## Motivation and Context

Reported against `lib/addax-storage` by a module code review (JDK 17 modernization angle): per-call pattern parsing and allocation in a name generated for every split file, plus a thread-safety trap if anyone "fixes" it by sharing the `SimpleDateFormat`.

## How has this been tested?

- `mvn -DskipTests compile -pl :addax-storage` (JDK 17) — clean.
- Manual trace: output still matches `yyyyMMdd_HHmmss_SSS_<8 random chars>`; `SimpleDateFormat` and java.time produce identical text for the same instant in the system zone.
- No unit tests added; per project convention, verification happens in the build environment manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual verification per project convention
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — n/a
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
