### PR TITLE
chore(ci): relax commit subject case and dot rules

### DIFF
--- a/.github/scripts/lint-commit-msg.sh
+++ b/.github/scripts/lint-commit-msg.sh
@@ -35,7 +35,7 @@ if (( ${#header} > 100 )); then
 fi
 
 allowed_types='feat|fix|refactor|perf|docs|test|build|ci|chore|revert'
-pattern="^(${allowed_types})\\(([a-z0-9][a-z0-9-]*)\\)(!)?: ([a-z][^.]*)$"
+pattern="^(${allowed_types})\\(([a-z0-9][a-z0-9-]*)\\)(!)?: (.+)$"
 
 if [[ ! "$header" =~ $pattern ]]; then
   cat >&2 <<'EOF'
@@ -44,7 +44,7 @@ expected: <type>(<scope>)!: <subject>
 allowed types: feat|fix|refactor|perf|docs|test|build|ci|chore|revert
 rules:
 - scope is mandatory and uses [a-z0-9-]
-- subject starts with lowercase and must not end with '.'
+- subject is free text: dots and mixed case are allowed
 - header length <= 100
 EOF
   echo "actual: $header" >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ sh addax.sh -job /path/to/job.json
 - 必须使用英文。
 - `type` 必填，且只能是：`feat`、`fix`、`refactor`、`perf`、`docs`、`test`、`build`、`ci`、`chore`、`revert`。
 - `scope` 必填（本项目强制），用于标识模块或插件。
-- `subject` 使用祈使句现在时（如 add/fix/remove/refactor），首字母小写，不以句号结尾。
+- `subject` 使用祈使句现在时（如 add/fix/remove/refactor）；不强制小写开头，允许包含句点（如 `bump x from 1.0 to 2.0`、含 `java.time`/`build-module.sh` 等命名）。
 - 标题总长度不超过 100 个字符。
 - 单个 commit 只做一件事，禁止混入无关改动。
 


### PR DESCRIPTION
## Summary

Relaxes the commit-subject rules enforced by `.github/scripts/lint-commit-msg.sh`:

1. **Dots are now allowed in the subject** (previously `[^.]*` banned any `.` — stricter than the documented "no trailing period" rule, and it rejected natural subjects such as `...java.time...`, `repair build-module.sh ...`, or `bump x from 1.0 to 2.0`).
2. **The subject no longer has to start with a lowercase letter**, so e.g. dependabot-style capitalized subjects are accepted as long as the mandatory `<type>(<scope>):` prefix is present (e.g. `chore(deps): Bump com.databend:databend-jdbc from 0.1.2 to 0.3.1`).

## What type of change is this?
- [x] Chore / Refactor

## Changes

- `.github/scripts/lint-commit-msg.sh`: subject pattern `([a-z][^.]*)` → `(.+)`; error message updated accordingly.
- `AGENTS.md` (CLAUDE.md is a symlink to it): the "首字母小写，不以句号结尾" guidance replaced with "不强制小写开头，允许包含句点".

Unchanged and still enforced: mandatory `<type>(<scope>)` prefix (type whitelist, scope `[a-z0-9-]`), optional `!`, header length ≤ 100, `why:`/`what:`/`impact:` bodies for `feat|fix|refactor|perf`, merge/fixup/squash header exemptions.

## Motivation and Context

Follow-up to a review of PR #1119 / merged dependabot PRs (#1454, #1459, #1468): bare `Bump ...` titles still fail (no type/scope prefix) and should be authored or squashed with the conventional form; with this change, a prefixed `chore(deps): Bump ... from 1.0 to 2.0` (which Dependabot can be configured to generate via `commit-message.prefix`) passes linting.

## How has this been tested?

Test matrix run against the updated script:

| header | result |
|---|---|
| `chore(deps): Bump com.databend:databend-jdbc from 0.1.2 to 0.3.1` | PASS |
| `refactor(lib-storage): format split file names with java.time` (+ body) | PASS |
| `fix(script): repair build-module.sh base paths and CLI options` (+ body) | PASS |
| `feat(core): do something.` (+ body) | PASS |
| `docs(readme): lower-case subject still fine` | PASS |
| `Bump com.databend:databend-jdbc from 0.1.2 to 0.3.1` (no prefix) | FAIL (unchanged) |
| `feat(): missing scope` | FAIL (unchanged) |
| `unknown(lib-storage): not an allowed type` | FAIL (unchanged) |
| header > 100 chars | FAIL (unchanged) |
| `Merge branch foo` / `fixup! ...` | PASS (unchanged exemptions) |

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — n/a, manual test matrix
- [x] I ran a local build and fixed any compilation issues. — n/a (shell script), linted the commit itself
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — AGENTS.md updated
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
