### PR TITLE
perf(lib-storage): parse sequence-file column config once per file

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -21,7 +21,6 @@
 
 package com.wgzhao.addax.storage.reader;
 
-import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.wgzhao.addax.core.base.Constant;
 import com.wgzhao.addax.core.base.Key;
@@ -264,26 +263,25 @@ public final class StorageReaderUtil
     }
 
     /**
-     * Transport one record by parsing a single line of text.
+     * Transport one record parsed from a single line of text.
+     *
+     * <p>Callers that loop over many records (e.g. per-file readers) should resolve the
+     * column configuration once and reuse this overload; re-reading and re-deserializing
+     * the column config for every record dominates the cost on large files.
      *
      * @param recordSender sender for the processed record
-     * @param configuration configuration containing column and delimiter info
-     * @param taskPluginCollector collector for error handling
+     * @param columnConfigs resolved column configuration, or null for untyped passthrough
      * @param line the line of text to parse
+     * @param fieldDelimiter the character separating fields within the line
+     * @param nullFormat format string representing null values, or null
+     * @param taskPluginCollector collector for error handling
      */
-    public static void transportOneRecord(RecordSender recordSender, Configuration configuration,
-            TaskPluginCollector taskPluginCollector, String line)
+    public static void transportOneRecord(RecordSender recordSender, List<ColumnEntry> columnConfigs,
+            String line, char fieldDelimiter, String nullFormat, TaskPluginCollector taskPluginCollector)
     {
-        List<ColumnEntry> column = getListColumnEntry(configuration, Key.COLUMN);
-        // The nullFormat has no default value
-        String nullFormat = configuration.getString(Key.NULL_FORMAT);
-
-        // Note: default value is ',', fieldDelimiter could be \n(lineDelimiter) for no fieldDelimiter
-        Character fieldDelimiter = configuration.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
-
         String[] sourceLine = splitPreservingEmptyFields(line, fieldDelimiter);
 
-        transportOneRecord(recordSender, column, sourceLine, nullFormat, taskPluginCollector);
+        transportOneRecord(recordSender, columnConfigs, sourceLine, nullFormat, taskPluginCollector);
     }
 
     /**
@@ -463,9 +461,17 @@ public final class StorageReaderUtil
             return null;
         }
 
-        List<ColumnEntry> result = new ArrayList<>();
+        // Copy the parsed JSON objects straight into ColumnEntry beans. Serializing each
+        // object back to JSON text only to re-parse it allocates two strings per column
+        // and is pointless when setFormat() already builds the DateFormat for us.
+        List<ColumnEntry> result = new ArrayList<>(lists.size());
         for (final JSONObject object : lists) {
-            result.add(JSON.parseObject(object.toJSONString(), ColumnEntry.class));
+            ColumnEntry entry = new ColumnEntry();
+            entry.setIndex(object.getInteger(Key.INDEX));
+            entry.setType(object.getString(Key.TYPE));
+            entry.setValue(object.getString(Key.VALUE));
+            entry.setFormat(object.getString(Key.FORMAT));
+            result.add(entry);
         }
         return result;
     }

--- a/plugin/reader/hdfsreader/src/main/java/com/wgzhao/addax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/plugin/reader/hdfsreader/src/main/java/com/wgzhao/addax/plugin/reader/hdfsreader/DFSUtil.java
@@ -24,6 +24,7 @@ import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONWriter;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import com.wgzhao.addax.core.base.Constant;
 import com.wgzhao.addax.core.base.Key;
 import com.wgzhao.addax.core.element.ColumnEntry;
 import com.wgzhao.addax.core.exception.AddaxException;
@@ -282,6 +283,13 @@ public class DFSUtil
     {
         LOG.info("Begin to read the sequence file [{}].", sourceSequenceFilePath);
 
+        // Resolve the column layout once per file; doing it per record (as the removed
+        // Configuration-based entry point did) deserializes the same JSON config on
+        // every row and dominates the read cost on large sequence files.
+        List<ColumnEntry> columns = StorageReaderUtil.getListColumnEntry(readerSliceConfig, Key.COLUMN);
+        String nullFormat = readerSliceConfig.getString(Key.NULL_FORMAT);
+        char fieldDelimiter = readerSliceConfig.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
+
         Path seqFilePath = new Path(sourceSequenceFilePath);
         try (SequenceFile.Reader reader = new SequenceFile.Reader(this.hadoopConf, SequenceFile.Reader.file(seqFilePath))) {
             //获取SequenceFile.Reader实例
@@ -289,8 +297,10 @@ public class DFSUtil
             Writable key = (Writable) ReflectionUtils.newInstance(reader.getKeyClass(), this.hadoopConf);
             Text value = new Text();
             while (reader.next(key, value)) {
-                if (StringUtils.isNotBlank(value.toString())) {
-                    StorageReaderUtil.transportOneRecord(recordSender, readerSliceConfig, taskPluginCollector, value.toString());
+                String record = value.toString();
+                if (StringUtils.isNotBlank(record)) {
+                    StorageReaderUtil.transportOneRecord(recordSender, columns, record, fieldDelimiter, nullFormat,
+                            taskPluginCollector);
                 }
             }
         }


### PR DESCRIPTION
## Summary
hdfs reader's sequence-file path re-deserialized the JSON column configuration on **every record** (JSONObject → JSON text → ColumnEntry, twice per row), which dominates read cost on large sequence files. This PR makes the read path resolve columns once per file.

## What type of change is this?
- [x] Performance improvement

## Changes
- `lib/addax-storage` `StorageReaderUtil.getListColumnEntry`: copy parsed `JSONObject`s into `ColumnEntry` beans via setters instead of serializing back to JSON text and re-parsing.
- `StorageReaderUtil`: new `transportOneRecord(recordSender, columnConfigs, line, fieldDelimiter, nullFormat, collector)` overload that takes pre-resolved columns; removed the `Configuration`-based entry point whose only caller was the seq loop.
- `plugin-hdfsreader` `DFSUtil.sequenceFileStartRead`: resolve columns/nullFormat/fieldDelimiter once before the record loop; `Text.toString()` now called once per record instead of twice.

## Motivation and Context
Per-record config parsing is pure waste: the column layout of a file never changes between rows. The CSV path in the same module already resolved columns once per file (`StorageReaderUtil.doReadFromStream`); the seq path was the only leftover hot loop.

## How has this been tested?
- Build: `mvn -pl :hdfsreader -am package -DskipTests -T1C` (JDK 17) passes.
- Unit tests: modules in this repo carry no automated test sources; functional verification is performed manually in the project's build environment.
- Behavior is unchanged apart from allocation/parse count: field splitting keeps empty fields, `nullFormat` and type conversion logic are untouched.

## Release notes
Performance improvement for reading HDFS sequence files (one config parse per file instead of per row).

## Breaking changes / Migration
The public `transportOneRecord(RecordSender, Configuration, TaskPluginCollector, String)` overload in `lib-storage` was removed. It had a single in-repo caller (the seq loop) which now uses the resolved-columns overload; external consumers should resolve columns once via `getListColumnEntry` and call the new overload per line.
