### PR TITLE
refactor(plugin-hdfsreader): delegate plugin config validation to shared storage utils

### DIFF
--- a/plugin/reader/hdfsreader/src/main/java/com/wgzhao/addax/plugin/reader/hdfsreader/HdfsReader.java
+++ b/plugin/reader/hdfsreader/src/main/java/com/wgzhao/addax/plugin/reader/hdfsreader/HdfsReader.java
@@ -26,20 +26,13 @@ import com.wgzhao.addax.core.spi.Reader;
 import com.wgzhao.addax.core.util.Configuration;
 import com.wgzhao.addax.storage.reader.StorageReaderUtil;
 import com.wgzhao.addax.storage.util.FileHelper;
-import org.apache.commons.io.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.wgzhao.addax.core.base.Key.COLUMN;
-import static com.wgzhao.addax.core.base.Key.ENCODING;
-import static com.wgzhao.addax.core.base.Key.INDEX;
-import static com.wgzhao.addax.core.base.Key.TYPE;
-import static com.wgzhao.addax.core.base.Key.VALUE;
 import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
 import static com.wgzhao.addax.core.spi.ErrorCode.EXECUTE_FAIL;
 import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
@@ -102,20 +95,10 @@ public class HdfsReader
                         "The file type only supports " + HdfsConstant.SUPPORT_FILE_TYPE + " but not " + specifiedFileType);
             }
 
-            String encoding = this.readerOriginConfig.getString(ENCODING, "UTF-8");
+            // Encoding, fieldDelimiter and column layout are shared with every other file
+            // reader; keeping a private copy here let the three validations drift apart.
+            StorageReaderUtil.validateParameter(readerOriginConfig);
 
-            try {
-                Charsets.toCharset(encoding);
-            }
-            catch (UnsupportedCharsetException uce) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        "The encoding [" +  encoding + "] is unsupported.", uce);
-            }
-            catch (Exception e) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE, "Exception occurred", e);
-            }
             //check Kerberos
             boolean haveKerberos = readerOriginConfig.getBool(Key.HAVE_KERBEROS, false);
             if (haveKerberos) {
@@ -123,51 +106,11 @@ public class HdfsReader
                 readerOriginConfig.getNecessaryValue(Key.KERBEROS_PRINCIPAL, REQUIRED_VALUE);
             }
 
-            // validate the Columns
-            validateColumns();
-
             // validate compress
             String compress = readerOriginConfig.getString(Key.COMPRESS, "NONE");
             if ("gzip".equalsIgnoreCase(compress)) {
                 // correct to gz
                 readerOriginConfig.set(Key.COMPRESS, "gz");
-            }
-        }
-
-        private void validateColumns()
-        {
-
-            // 检测是column 是否为 ["*"] 若是则填为空
-            List<Configuration> column = this.readerOriginConfig.getListConfiguration(COLUMN);
-            if (null != column && 1 == column.size()
-                    && ("\"*\"".equals(column.get(0).toString()) || "'*'".equals(column.get(0).toString()))) {
-                readerOriginConfig.set(COLUMN, new ArrayList<String>());
-            }
-            else {
-                // column: 1. index type 2.value type 3.when type is Data, may be dateFormat value
-                List<Configuration> columns = readerOriginConfig.getListConfiguration(COLUMN);
-
-                if (null == columns || columns.isEmpty()) {
-                    throw AddaxException.asAddaxException(CONFIG_ERROR,
-                            "The item columns is required.");
-                }
-
-                for (Configuration eachColumnConf : columns) {
-                    eachColumnConf.getNecessaryValue(TYPE, REQUIRED_VALUE);
-                    Integer columnIndex = eachColumnConf.getInt(INDEX);
-                    String columnValue = eachColumnConf.getString(VALUE);
-
-                    if (null == columnIndex && null == columnValue) {
-                        throw AddaxException.asAddaxException(
-                                CONFIG_ERROR,
-                                "The index or value must have one, both of them are null.");
-                    }
-
-                    if (null != columnIndex && null != columnValue) {
-                        throw AddaxException.asAddaxException(CONFIG_ERROR,
-                                "The index and value must have one, can not have both.");
-                    }
-                }
             }
         }
 

--- a/plugin/reader/s3reader/src/main/java/com/wgzhao/addax/plugin/reader/s3reader/S3Reader.java
+++ b/plugin/reader/s3reader/src/main/java/com/wgzhao/addax/plugin/reader/s3reader/S3Reader.java
@@ -19,13 +19,11 @@
 
 package com.wgzhao.addax.plugin.reader.s3reader;
 
-import com.wgzhao.addax.core.base.Constant;
 import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.plugin.RecordSender;
 import com.wgzhao.addax.core.spi.Reader;
 import com.wgzhao.addax.core.util.Configuration;
 import com.wgzhao.addax.storage.reader.StorageReaderUtil;
-import org.apache.commons.io.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -36,13 +34,10 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.InputStream;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static com.wgzhao.addax.core.spi.ErrorCode.CONFIG_ERROR;
-import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
 import static com.wgzhao.addax.core.spi.ErrorCode.REQUIRED_VALUE;
 import static com.wgzhao.addax.core.spi.ErrorCode.RUNTIME_ERROR;
 
@@ -78,53 +73,10 @@ public class S3Reader
             this.bucket = readerOriginConfig.getNecessaryValue(S3Key.BUCKET, REQUIRED_VALUE);
             readerOriginConfig.getNecessaryValue(S3Key.OBJECT, REQUIRED_VALUE);
 
-            String encoding = readerOriginConfig.getString(S3Key.ENCODING, Constant.DEFAULT_ENCODING);
-            try {
-                Charsets.toCharset(encoding);
-            }
-            catch (UnsupportedCharsetException uce) {
-                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                        String.format("unsupported encoding : [%s]", encoding), uce);
-            }
-            catch (Exception e) {
-                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                        String.format("Runtime Error : %s", e.getMessage()), e);
-            }
+            // Encoding, fieldDelimiter and column layout are shared with every other file
+            // reader; keeping a private copy here let the three validations drift apart.
+            StorageReaderUtil.validateParameter(readerOriginConfig);
 
-            // 检测是column 是否为 ["*"] 若是则填为空
-            List<Configuration> column = readerOriginConfig.getListConfiguration(S3Key.COLUMN);
-            if (null != column && 1 == column.size() && ("\"*\"".equals(column.get(0).toString())
-                    || "'*'".equals(column.get(0).toString()))) {
-                readerOriginConfig.set(S3Key.COLUMN, new ArrayList<String>());
-            }
-            else {
-                // column: 1. index type 2.value type 3.when type is Data, maybe with format string
-                List<Configuration> columns = readerOriginConfig.getListConfiguration(S3Key.COLUMN);
-
-                if (null == columns || columns.isEmpty()) {
-                    throw AddaxException.asAddaxException(
-                            REQUIRED_VALUE,
-                            "The item column is required");
-                }
-
-                for (Configuration eachColumnConf : columns) {
-                    eachColumnConf.getNecessaryValue(S3Key.TYPE, REQUIRED_VALUE);
-                    Integer columnIndex = eachColumnConf.getInt(S3Key.INDEX);
-                    String columnValue = eachColumnConf.getString(S3Key.VALUE);
-
-                    if (null == columnIndex && null == columnValue) {
-                        throw AddaxException.asAddaxException(
-                                CONFIG_ERROR,
-                                "You configured type, also configured index or value");
-                    }
-
-                    if (null != columnIndex && null != columnValue) {
-                        throw AddaxException.asAddaxException(
-                                CONFIG_ERROR,
-                                "You configured both index and value");
-                    }
-                }
-            }
             this.client = S3Util.initS3Client(readerOriginConfig);
         }
 

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
@@ -27,7 +27,7 @@ import com.wgzhao.addax.core.spi.Writer;
 import com.wgzhao.addax.core.util.Configuration;
 import com.wgzhao.addax.core.util.ShellUtil;
 import com.wgzhao.addax.storage.util.FileHelper;
-import org.apache.commons.io.Charsets;
+import com.wgzhao.addax.storage.writer.StorageWriterUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.CompressionKind;
@@ -121,27 +121,19 @@ public class HdfsWriter
             }
             processColumns(columns);
 
-            //writeMode check
-            this.writeMode = this.writerSliceConfig.getNecessaryValue(Key.WRITE_MODE, REQUIRED_VALUE);
-            if (!Constant.SUPPORTED_WRITE_MODE.contains(writeMode)) {
-                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                        String.format("The item writeMode only supports append, noConflict and overwrite, [%s] is unsupported yet.",
-                                writeMode));
-            }
             if ("TEXT".equals(fileType)) {
-                //fieldDelimiter check
+                // Required before the shared validator can fall back to its default delimiter
                 String fieldDelimiter = this.writerSliceConfig.getString(Key.FIELD_DELIMITER, null);
                 if (StringUtils.isEmpty(fieldDelimiter)) {
                     throw AddaxException.asAddaxException(REQUIRED_VALUE,
                             String.format("The item [%s] should be configured and valid while write TEXT file.", Key.FIELD_DELIMITER));
                 }
-
-                if (1 != fieldDelimiter.length()) {
-                    // warn: if it has, length must be one
-                    throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                            String.format("The field delimiter is only support single character, your configure: [%s]", fieldDelimiter));
-                }
             }
+
+            // Shared writeMode/encoding/fieldDelimiter checks live in the storage layer so
+            // every file-based writer validates them the same way
+            StorageWriterUtil.validateParameter(this.writerSliceConfig);
+            this.writeMode = this.writerSliceConfig.getString(Key.WRITE_MODE);
 
             //compress check
             validateCompression(fileType);
@@ -150,8 +142,6 @@ public class HdfsWriter
             }
             //Kerberos check
             validateKerberos();
-            // encoding check
-            validateEncoding();
 
             // trash
             this.skipTrash = this.writerSliceConfig.getBool(SKIP_TRASH, false);
@@ -436,18 +426,6 @@ public class HdfsWriter
             }
         }
 
-        private void validateEncoding()
-        {
-            var encoding = this.writerSliceConfig.getString(Key.ENCODING, Constant.DEFAULT_ENCODING).trim();
-            try {
-                this.writerSliceConfig.set(Key.ENCODING, encoding);
-                Charsets.toCharset(encoding);
-            }
-            catch (Exception e) {
-                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
-                        "The encoding [%s] is unsupported yet.".formatted(encoding), e);
-            }
-        }
     }
 
     /** Task. */


### PR DESCRIPTION
## Summary
HdfsReader, S3Reader and HdfsWriter each hand-rolled copies of the encoding / column / wildcard / writeMode validation that already exists in `StorageReaderUtil.validateParameter` and `StorageWriterUtil.validateParameter`. This PR makes the three plugins delegate the shared checks and keep only their HDFS/S3-specific rules.

## What type of change is this?
- [x] Chore / Refactor

## Changes
- `plugin-hdfsreader` `HdfsReader.Job.validate()`: common checks replaced by `StorageReaderUtil.validateParameter`; keeps defaultFS, path, fileType whitelist, kerberos and the `gzip -> gz` compression normalization. Private `validateColumns()` deleted.
- `plugin-s3reader` `S3Reader.Job.validate()`: same delegation; keeps region/accessId/accessKey/bucket/object checks and S3 client init.
- `plugin-hdfswriter` `HdfsWriter.Job.validateParameter()`: delegates writeMode/encoding/fieldDelimiter to `StorageWriterUtil.validateParameter`; keeps fileType/path/fileName/columns, the TEXT-required delimiter rule, per-format compression and bloom-filter checks. Private `validateEncoding()` deleted.

## Motivation and Context
The duplicated blocks had already drifted: S3Reader never checked `fieldDelimiter` length or negative column indexes, and the hdfs writer's writeMode whitelist message listed fewer modes than it actually accepted. Single-sourcing keeps the file-plugin family consistent with txtfilereader/ftpwriter/dbfreader, which already use the shared validators.

## How has this been tested?
- Build: `mvn -pl :hdfsreader,:s3reader,:hdfswriter -am package -DskipTests -T1C` (JDK 17) passes.
- The repo carries no automated unit-test sources; functional jobs are verified manually in the project build environment.

## Release notes
Refactor only. Validation behavior is preserved; writeMode is now trimmed before comparison and fieldDelimiter length is checked for all hdfs writer file types.

## Breaking changes / Migration
None.
