### PR TITLE
fix(lib-storage): read and write newline fieldDelimiter without commons-csv

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/reader/StorageReaderUtil.java
@@ -207,9 +207,6 @@ public final class StorageReaderUtil
             Configuration readerSliceConfig, RecordSender recordSender,
             TaskPluginCollector taskPluginCollector)
     {
-        // Configure CSV parser
-        CSVFormat.Builder csvFormatBuilder = CSVFormat.DEFAULT.builder();
-
         // Get field delimiter
         String delimiterInStr = readerSliceConfig.getString(Key.FIELD_DELIMITER);
         if (delimiterInStr != null && delimiterInStr.length() != 1) {
@@ -219,12 +216,30 @@ public final class StorageReaderUtil
             LOG.warn("Uses [{}] as delimiter by default", Constant.DEFAULT_FIELD_DELIMITER);
         }
 
-        // Note: default value is ',', fieldDelimiter could be \n(lineDelimiter) for no fieldDelimiter
-        Character fieldDelimiter = readerSliceConfig.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
-        csvFormatBuilder.setDelimiter(fieldDelimiter);
-
         // Null format configuration, note: no default value '\N'
         String nullFormat = readerSliceConfig.getString(Key.NULL_FORMAT);
+        List<ColumnEntry> column = getListColumnEntry(readerSliceConfig, Key.COLUMN);
+
+        // Note: default value is ',', fieldDelimiter could be \n(lineDelimiter) for no fieldDelimiter.
+        // commons-csv refuses line-break delimiters outright, so a '\n' (or '\r') fieldDelimiter is
+        // treated as "no field delimiter": each physical line is one single-field record, read
+        // line by line instead of parsed as CSV.
+        char fieldDelimiter = readerSliceConfig.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
+        if (fieldDelimiter == '\n' || fieldDelimiter == '\r') {
+            boolean skipHeader = readerSliceConfig.getBool(Key.SKIP_HEADER, Constant.DEFAULT_SKIP_HEADER);
+            try {
+                readPlainLines(reader, column, nullFormat, skipHeader, recordSender, taskPluginCollector);
+            }
+            catch (IOException ioe) {
+                throw AddaxException.asAddaxException(
+                        IO_ERROR, String.format("Failed to read file [%s]", fileName), ioe);
+            }
+            return;
+        }
+
+        // Configure CSV parser
+        CSVFormat.Builder csvFormatBuilder = CSVFormat.DEFAULT.builder();
+        csvFormatBuilder.setDelimiter(fieldDelimiter);
         csvFormatBuilder.setNullString(nullFormat);
 
         // Header handling
@@ -232,8 +247,6 @@ public final class StorageReaderUtil
             csvFormatBuilder.setHeader();
             csvFormatBuilder.setSkipHeaderRecord(true);
         }
-
-        List<ColumnEntry> column = getListColumnEntry(readerSliceConfig, Key.COLUMN);
 
         // Process each line
         try (CSVParser csvParser = CSVParser.parse(reader, csvFormatBuilder.get())) {
@@ -259,6 +272,30 @@ public final class StorageReaderUtil
         }
         catch (Exception e) {
             throw AddaxException.asAddaxException(RUNTIME_ERROR, e);
+        }
+    }
+
+    /**
+     * Read records where a physical line is the whole record (fieldDelimiter "\n"/"\r").
+     *
+     * <p>Mirrors the commons-csv semantics used for regular delimiters: the first line is
+     * dropped as a header when requested and completely empty lines produce no record.
+     */
+    private static void readPlainLines(BufferedReader reader, List<ColumnEntry> column, String nullFormat,
+            boolean skipHeader, RecordSender recordSender, TaskPluginCollector taskPluginCollector)
+            throws IOException
+    {
+        String line;
+        boolean headerPending = skipHeader;
+        while ((line = reader.readLine()) != null) {
+            if (headerPending) {
+                headerPending = false;
+                continue;
+            }
+            if (line.isEmpty()) {
+                continue;
+            }
+            transportOneRecord(recordSender, column, new String[] {line}, nullFormat, taskPluginCollector);
         }
     }
 

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -435,12 +435,7 @@ public final class StorageWriterUtil
             Configuration config, TaskPluginCollector taskPluginCollector)
             throws IOException
     {
-        CSVFormat.Builder csvBuilder = CSVFormat.DEFAULT.builder();
-        csvBuilder.setRecordSeparator(IOUtils.LINE_SEPARATOR_UNIX);
-
         String nullFormat = config.getString(Key.NULL_FORMAT);
-        csvBuilder.setNullString(nullFormat);
-
         String dateFormat = config.getString(Key.DATE_FORMAT);
         DateFormat dateParse = StringUtils.isNotBlank(dateFormat) ? new SimpleDateFormat(dateFormat) : null;
 
@@ -450,6 +445,18 @@ public final class StorageWriterUtil
             throw AddaxException.illegalConfigValue(Key.FIELD_DELIMITER, delimiterInStr);
         }
         char fieldDelimiter = config.getChar(Key.FIELD_DELIMITER, Constant.DEFAULT_FIELD_DELIMITER);
+
+        // '\n' (or '\r') as fieldDelimiter is the historical "no field separator" marker (one
+        // field per physical line). commons-csv rejects line-break delimiters, so those records
+        // are emitted manually instead of going through CSVPrinter.
+        if (fieldDelimiter == '\n' || fieldDelimiter == '\r') {
+            writePlainRecords(lineReceiver, writer, nullFormat, dateParse, fieldDelimiter, taskPluginCollector);
+            return;
+        }
+
+        CSVFormat.Builder csvBuilder = CSVFormat.DEFAULT.builder();
+        csvBuilder.setRecordSeparator(IOUtils.LINE_SEPARATOR_UNIX);
+        csvBuilder.setNullString(nullFormat);
         csvBuilder.setDelimiter(fieldDelimiter);
 
         // Handle headers
@@ -465,6 +472,27 @@ public final class StorageWriterUtil
                 if (result != null) {
                     csvPrinter.printRecord(result);
                 }
+            }
+        }
+    }
+
+    /**
+     * Write records whose fields are separated by a line break (fieldDelimiter "\n"/"\r").
+     *
+     * <p>Fields are joined with the delimiter and the record is terminated by '\n', which
+     * puts every field of one record on its own physical line.
+     */
+    private static void writePlainRecords(RecordReceiver lineReceiver, BufferedWriter writer, String nullFormat,
+            DateFormat dateParse, char fieldDelimiter, TaskPluginCollector taskPluginCollector)
+            throws IOException
+    {
+        String separator = String.valueOf(fieldDelimiter);
+        Record record;
+        while ((record = lineReceiver.getFromReader()) != null) {
+            List<String> result = recordToList(record, nullFormat, dateParse, taskPluginCollector);
+            if (result != null) {
+                writer.write(String.join(separator, result));
+                writer.write('\n');
             }
         }
     }


### PR DESCRIPTION
## Summary
`fieldDelimiter: "\n"` is the documented "no field delimiter" marker (one physical line = one field), but the commons-csv based read/write paths reject line-break delimiters and blow up at slice runtime with "The delimiter must not be a line break". This PR restores the legacy semantics by routing newline delimiters around commons-csv.

## What type of change is this?
- [x] Bugfix

## Changes
- `StorageReaderUtil.doReadFromStream`: a `'\n'` or `'\r'` fieldDelimiter now skips CSVParser entirely and reads line by line, emitting each physical line as one single-field record. The first line is dropped when `skipHeader` is set and completely empty lines produce no record, mirroring commons-csv behavior. `nullFormat` equality and typed-column conversion are handled by the existing transport path.
- `StorageWriterUtil.writeToCSV`: the same delimiters are emitted by a plain joiner (fields of a record joined by the delimiter, record terminated by `\n`) instead of CSVPrinter, so each field lands on its own physical line — symmetric with the reader and with the hdfs/s3 text writers, which already join records manually.

## Motivation and Context
The semantics were documented in code comments (`fieldDelimiter could be \n(lineDelimiter) for no fieldDelimiter`) but were unfulfillable after the commons-csv migration: commons-csv forbids `\n`/`\r` as delimiters, so such jobs failed late at read time with a confusing exception.

## How has this been tested?
- Build: `mvn -pl :addax-storage -am package -DskipTests -T1C` (JDK 17) passes.
- The repo carries no automated unit-test sources; functional verification happens manually in the project build environment.

## Release notes
Text jobs using `fieldDelimiter: "\n"` work again with their legacy single-field-per-line semantics.

## Breaking changes / Migration
None — behavior for all non-newline delimiters is byte-identical to before.
