### PR TITLE
fix(lib-storage): reject unsupported compress modes during writer validation

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -163,10 +163,34 @@ public final class StorageWriterUtil
         if (StringUtils.isBlank(compress)) {
             writerConfiguration.set(Key.COMPRESS, null);
             LOG.debug("No compression specified");
+            return;
         }
-        else {
+
+        // Accept exactly what createWriter can actually produce, so an unsupported mode
+        // fails during job validation instead of midway through writing files.
+        String normalized = normalizeCompressName(compress);
+        Set<String> outputCompressorNames = new CompressorStreamFactory().getOutputStreamCompressorNames();
+        if ("none".equals(normalized) || "zip".equals(normalized) || outputCompressorNames.contains(normalized)) {
             LOG.debug("Compression specified: {}", compress);
+            return;
         }
+        throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE, String.format(
+                "The compress mode [%s] is unsupported; supported modes: none, zip, %s",
+                compress, String.join(", ", outputCompressorNames)));
+    }
+
+    /**
+     * Canonicalize a user-supplied compress name to the spelling commons-compress
+     * understands. Locale.ROOT keeps locale-sensitive JVMs (e.g. tr_TR) from mangling
+     * ASCII names such as "ZIP" into "zıp".
+     */
+    private static String normalizeCompressName(String compress)
+    {
+        return switch (compress.toLowerCase(Locale.ROOT)) {
+            case "gzip" -> "gz";
+            case "bz2" -> "bzip2";
+            default -> compress.toLowerCase(Locale.ROOT);
+        };
     }
 
     /**
@@ -362,13 +386,7 @@ public final class StorageWriterUtil
             return new BufferedWriter(new OutputStreamWriter(outputStream, encoding));
         }
 
-        // Normalize compress name for compatibility; Locale.ROOT keeps locale-sensitive JVMs
-        // (e.g. tr_TR) from mangling ASCII names such as "ZIP" -> "zıp"
-        String normalizedCompress = switch (compress.toLowerCase(Locale.ROOT)) {
-            case "gzip" -> "gz";
-            case "bz2" -> "bzip2";
-            default -> compress.toLowerCase(Locale.ROOT);
-        };
+        String normalizedCompress = normalizeCompressName(compress);
 
         if ("zip".equals(normalizedCompress)) {
             ZipCycleOutputStream zos = new ZipCycleOutputStream(outputStream, fileName);

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
@@ -301,7 +301,7 @@ public class HdfsHelper
             case "ZSTD" -> org.apache.hadoop.io.compress.ZStandardCodec.class;
             case "DEFLATE", "ZLIB" -> org.apache.hadoop.io.compress.DeflateCodec.class;
             default -> throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
-                    String.format("The compress mode [%s} is unsupported yet.", compress));
+                    String.format("The compress mode [%s] is unsupported yet.", compress));
         };
         return codecClass;
     }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
@@ -79,6 +79,10 @@ public class HdfsWriter
         /** Support format. */
         public static final Set<String> SUPPORT_FORMAT = Set.of("ORC", "PARQUET", "TEXT");
 
+        // Codecs the text writer can emit; keep in sync with HdfsHelper.getCompressCodec
+        private static final Set<String> TEXT_COMPRESS_CODECS = Set.of(
+                "GZIP", "BZIP2", "SNAPPY", "LZ4", "ZSTD", "DEFLATE", "ZLIB");
+
         // Create record for decimal configuration
         private record DecimalConfig(int precision, int scale) {}
 
@@ -422,6 +426,17 @@ public class HdfsWriter
                                         The PARQUET format only supports [%s] compression.
                                         Your configure [%s] is unsupported yet.
                                         """.formatted(Arrays.toString(CompressionCodecName.values()), compress));
+                    }
+                }
+                case "TEXT" -> {
+                    // Codecs mirror HdfsHelper.getCompressCodec; LZO is absent because writing it
+                    // needs the hadoop-lzo native library, which this project does not bundle.
+                    if (!"NONE".equals(compress) && !TEXT_COMPRESS_CODECS.contains(compress)) {
+                        throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                                """
+                                        The TEXT format only supports NONE, [%s] compression.
+                                        Your configure [%s] is unsupported yet (LZO writing requires the hadoop-lzo native library).
+                                        """.formatted(String.join(", ", TEXT_COMPRESS_CODECS), compress));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
`compress: "lzo"` (or any other unsupported mode) on hdfs text files only failed **while writing data**, after a job had already staged temporary files; the shared writer validator accepted anything. This PR makes invalid compress modes fail during job validation with a clear message.

## What type of change is this?
- [x] Bugfix

## Changes
- `StorageWriterUtil.validateCompression`: now validates against exactly what the shared writer can produce — `none`, `zip`, and the compressor names commons-compress actually supports (queried from `CompressorStreamFactory`, same factory `createWriter` uses). New `normalizeCompressName` helper is shared with `createWriter` so aliases (`gzip`→`gz`, `bz2`→`bzip2`) stay consistent between validation and writing.
- `HdfsWriter.Job.validateCompression`: added a `TEXT` branch whose whitelist mirrors `HdfsHelper.getCompressCodec`. `"lzo"` now fails at job init with a hint that it needs the hadoop-lzo native library (not bundled), instead of exploding inside `TextWriter` mid-run.
- `HdfsHelper.getCompressCodec`: fixed broken `[%s}` message placeholder.

## Motivation and Context
Fail-fast validation: a mistyped compress value previously passed both the shared validator (a no-op) and the hdfswriter validator (which only checked ORC/PARQUET enums), and only surfaced at task runtime with an unhelpful error. The project does not bundle hadoop-lzo, so LZO can never succeed on the write path and should be rejected up front rather than discovered per task.

## How has this been tested?
- Build: `mvn -pl :addax-storage,:hdfswriter -am package -DskipTests -T1C` (JDK 17) passes.
- The repo carries no automated unit-test sources; functional jobs are verified manually in the project build environment.

## Release notes
Unsupported `compress` values (e.g. `lzo` on text files) now fail fast at job validation with a message listing the supported modes.

## Breaking changes / Migration
None for valid configurations. Note: hdfs ORC/PARQUET enum validation is unchanged.
