### PR TITLE
fix(lib-storage): scope compress validation to commons-compress writers

### DIFF
--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -92,7 +92,12 @@ public final class StorageWriterUtil
 
     /**
      * Validate writer configuration parameters including write mode, encoding,
-     * compression, and field delimiter.
+     * and field delimiter.
+     *
+     * <p>Compression is deliberately not checked here: it is only meaningful for
+     * writers that emit through {@link #writeToStream}, while format-native writers
+     * (ORC/PARQUET/TEXT on hdfs/s3) accept their own codec sets. Those writers must
+     * invoke {@link #validateCompression} explicitly, or validate codecs themselves.
      *
      * @param writerConfiguration the configuration to validate
      * @throws AddaxException if validation fails
@@ -101,7 +106,6 @@ public final class StorageWriterUtil
     {
         validateWriteMode(writerConfiguration);
         validateEncoding(writerConfiguration);
-        validateCompression(writerConfiguration);
         validateFieldDelimiter(writerConfiguration);
         validateFileFormat(writerConfiguration);
     }
@@ -153,11 +157,15 @@ public final class StorageWriterUtil
     }
 
     /**
-     * Validate the compression parameter.
+     * Validate the compression parameter against the codecs commons-compress can emit.
+     *
+     * <p>Only writers that write through {@link #writeToStream} (whose {@code createWriter}
+     * maps the mode via commons-compress) should call this; format-native writers such as
+     * the hdfs/s3 writer have their own per-format codec vocabularies.
      *
      * @param writerConfiguration configuration to validate
      */
-    private static void validateCompression(Configuration writerConfiguration)
+    public static void validateCompression(Configuration writerConfiguration)
     {
         String compress = writerConfiguration.getString(Key.COMPRESS);
         if (StringUtils.isBlank(compress)) {

--- a/plugin/writer/ftpwriter/src/main/java/com/wgzhao/addax/plugin/writer/ftpwriter/FtpWriter.java
+++ b/plugin/writer/ftpwriter/src/main/java/com/wgzhao/addax/plugin/writer/ftpwriter/FtpWriter.java
@@ -85,6 +85,8 @@ public class FtpWriter
             this.writerSliceConfig = this.getPluginJobConf();
             this.validateParameter();
             StorageWriterUtil.validateParameter(this.writerSliceConfig);
+            // files are emitted through writeToStream (commons-compress), so compress is checked here
+            StorageWriterUtil.validateCompression(this.writerSliceConfig);
             String keyPath = this.writerSliceConfig.getString(FtpKey.KEY_PATH, null);
             String keyPass = this.writerSliceConfig.getString(FtpKey.KEY_PASS, null);
 

--- a/plugin/writer/txtfilewriter/src/main/java/com/wgzhao/addax/plugin/writer/txtfilewriter/TxtFileWriter.java
+++ b/plugin/writer/txtfilewriter/src/main/java/com/wgzhao/addax/plugin/writer/txtfilewriter/TxtFileWriter.java
@@ -87,6 +87,8 @@ public class TxtFileWriter
                 LOG.warn("The `format` item has been deprecated; please use `dateFormat` for configuration.");
             }
             StorageWriterUtil.validateParameter(this.writerSliceConfig);
+            // files are emitted through writeToStream (commons-compress), so compress is checked here
+            StorageWriterUtil.validateCompression(this.writerSliceConfig);
         }
 
         private void validateParameter()


### PR DESCRIPTION

why: validateCompression hardened in #1529 runs for every validateParameter caller against the commons-compress codec names, but format-native writers (hdfswriter/s3writer) accept their own vocabularies, so valid jobs such as hdfswriter ORC with compress "SNAPPY" (a legal ORC CompressionKind) are now rejected at job init with the commons-compress "supported modes" message.

what: drop the compression check from StorageWriterUtil.validateParameter and expose validateCompression publicly; txtfilewriter/ftpwriter, which emit files through writeToStream (commons-compress), call it explicitly, while hdfswriter keeps validating codecs per format (CompressionKind / CompressionCodecName / hadoop codec whitelist) and s3writer returns to its write-time per-format checks.

impact: hdfswriter ORC/PARQUET/TEXT and s3writer compress configs valid before #1529 are accepted again; txtfilewriter/ftpwriter still reject unsupported compress modes during job init.