### PR TITLE
fix(plugin-hdfswriter): add lz4-java dependency so LZ4 codec works

### DIFF
--- a/plugin/writer/hdfswriter/pom.xml
+++ b/plugin/writer/hdfswriter/pom.xml
@@ -103,6 +103,13 @@
             <artifactId>parquet-hadoop-bundle</artifactId>
         </dependency>
 
+        <!-- hadoop-common declares lz4-java as provided (it ships it in its own distro),
+             so supply it explicitly or hadoop Lz4Codec fails with NoClassDefFoundError -->
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>

--- a/plugin/writer/s3writer/pom.xml
+++ b/plugin/writer/s3writer/pom.xml
@@ -182,6 +182,13 @@
             <version>${parquet.version}</version>
         </dependency>
 
+        <!-- hadoop-common declares lz4-java as provided (it ships it in its own distro),
+             so supply it explicitly or hadoop Lz4Codec fails with NoClassDefFoundError -->
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>


### PR DESCRIPTION
why: hadoop-common declares org.lz4:lz4-java as provided (it ships the jar in its own distribution), so parquet and hadoop LZ4 codecs throw NoClassDefFoundError: net/jpountz/lz4/LZ4Factory at write time whenever the plugin runs outside a hadoop distro.

what: declare the root-managed org.lz4:lz4-java (1.8.0, matching hadoop 3.3.6) as a compile dependency.

impact: PARQUET/TEXT files with LZ4 compression now write successfully; no version changes elsewhere.


---
Second commit:

why: like hdfswriter, s3writer depends on hadoop-common, which declares org.lz4:lz4-java as provided, so parquet files with LZ4 compression fail at write time with NoClassDefFoundError: net/jpountz/lz4/LZ4Factory.

what: declare the root-managed org.lz4:lz4-java (1.8.0, matching hadoop 3.3.6) as a compile dependency.

impact: PARQUET files with LZ4 compression now write successfully on s3writer.

