### PR TITLE
fix(plugin-hdfswriter): correct timestamp, date and collection encoding

### DIFF
--- a/plugin/reader/hdfsreader/pom.xml
+++ b/plugin/reader/hdfsreader/pom.xml
@@ -105,6 +105,13 @@
             <artifactId>parquet-hadoop-bundle</artifactId>
         </dependency>
 
+        <!-- hadoop-common declares lz4-java as provided (it ships it in its own distro),
+             so supply it explicitly or reading LZ4 parquet/text fails with NoClassDefFoundError -->
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
@@ -50,6 +50,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.wgzhao.addax.core.base.Key.HAVE_KERBEROS;
@@ -73,6 +74,16 @@ public class HdfsHelper
     protected org.apache.hadoop.conf.Configuration hadoopConf = null;
     private static final double DEFAULT_BLOOM_FILTER_FPP = 0.05d;
 
+    // Column rendering has to agree with Column.asString(), which formats in this same zone,
+    // otherwise a TIME value is written one offset away from every other representation of it
+    private static final String COLUMN_TIME_ZONE = "common.column.timeZone";
+    private static final String DEFAULT_COLUMN_TIME_ZONE = "GMT+8";
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+    private static final long NANOS_PER_MILLISECOND = 1_000_000L;
+
+    /** The zone used to render DATE/TIME columns. */
+    protected TimeZone columnTimeZone = TimeZone.getTimeZone(DEFAULT_COLUMN_TIME_ZONE);
+
     record BloomFilterConfig(String columns, double fpp)
     {
     }
@@ -81,6 +92,8 @@ public class HdfsHelper
     {
         hadoopConf = new org.apache.hadoop.conf.Configuration();
         String defaultFS = taskConfig.getString(Key.DEFAULT_FS);
+        this.columnTimeZone = TimeZone.getTimeZone(
+                taskConfig.getString(COLUMN_TIME_ZONE, DEFAULT_COLUMN_TIME_ZONE));
         Configuration hadoopSiteParams = taskConfig.getConfiguration(Key.HADOOP_CONFIG);
         JSONObject hadoopSiteParamsAsJsonObject = JSON.parseObject(taskConfig.getString(Key.HADOOP_CONFIG));
         if (null != hadoopSiteParams) {
@@ -376,15 +389,19 @@ public class HdfsHelper
      * When nanos is zero, delegates to the default {@code column.asString()} ({@code HH:mm:ss}).
      *
      * @param column the input column to format
+     * @param timeZone the zone the time-of-day is expressed in
      * @return formatted time string with full precision when applicable
      */
-    protected static String formatTimeWithNanos(Column column)
+    protected static String formatTimeWithNanos(Column column, TimeZone timeZone)
     {
         if (column.getType() == Column.Type.DATE && ((DateColumn) column).getSubType() == DateColumn.DateType.TIME) {
             long nanos = ((DateColumn) column).getNanos();
             if (nanos > 0) {
                 long timeMs = (Long) column.getRawData();
-                long totalNanosOfDay = (timeMs % 86_400_000L) * 1_000_000L + (nanos % 1_000_000L);
+                // The raw value is an instant, not a wall clock reading: apply the same zone the
+                // default asString() path uses, and floorMod so pre-1970 values stay in range
+                long millisOfDay = Math.floorMod(timeMs + timeZone.getOffset(timeMs), MILLIS_PER_DAY);
+                long totalNanosOfDay = millisOfDay * NANOS_PER_MILLISECOND + nanos % NANOS_PER_MILLISECOND;
                 return LocalTime.ofNanoOfDay(totalNanosOfDay).toString();
             }
         }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -71,10 +72,19 @@ public class OrcWriter
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
     private static final ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT =
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
-    // the type of the element in the array
-    private SupportHiveDataType elementType;
-    // the type of the value in the map
-    private SupportHiveDataType valueType;
+
+    /**
+     * The ORC schema together with the element/value type resolved for every configured column.
+     * <p>
+     * The collection types are held per column instead of as writer state: a table may declare
+     * several ARRAY or MAP columns whose element types differ, and a single field would keep only
+     * the last one parsed and apply it to all of them.
+     */
+    private record OrcLayout(TypeDescription schema,
+            List<SupportHiveDataType> elementTypes,
+            List<SupportHiveDataType> mapValueTypes)
+    {
+    }
 
     /** Orcwriter. */
     public OrcWriter(Configuration conf)
@@ -91,9 +101,10 @@ public class OrcWriter
      * @param record {@link Record}
      * @param columns table columns, {@link List}
      * @param taskPluginCollector {@link TaskPluginCollector}
+     * @param layout the schema and the per-column collection types
      */
     private void setRow(VectorizedRowBatch batch, int row, Record record, List<Configuration> columns,
-            TaskPluginCollector taskPluginCollector)
+            TaskPluginCollector taskPluginCollector, OrcLayout layout)
     {
         for (int i = 0; i < columns.size(); i++) {
             Configuration eachColumnConf = columns.get(i);
@@ -109,12 +120,14 @@ public class OrcWriter
             }
 
             if (type.startsWith("ARRAY")) {
-                appendArrayValue(row, recordColumn, (ListColumnVector) col);
+                appendArrayValue(row, recordColumn, (ListColumnVector) col,
+                        layout.elementTypes().get(i), eachColumnConf);
                 continue;
             }
 
             if (type.startsWith("MAP")) {
-                appendMapValue(row, recordColumn, (MapColumnVector) col);
+                appendMapValue(row, recordColumn, (MapColumnVector) col,
+                        layout.mapValueTypes().get(i), eachColumnConf);
                 continue;
             }
 
@@ -196,8 +209,11 @@ public class OrcWriter
      * @param row the row number in the batch
      * @param recordColumn the record column containing the array value
      * @param col the column vector to append the array value to
+     * @param elementType the element type declared for this column
+     * @param eachColumnConf the configuration of this column
      */
-    private void appendArrayValue(int row, Column recordColumn, ListColumnVector col)
+    private void appendArrayValue(int row, Column recordColumn, ListColumnVector col,
+            SupportHiveDataType elementType, Configuration eachColumnConf)
     {
         // "['value1','value2'] ,convert the string to a list of V
         String arrayString = recordColumn.asString();
@@ -212,7 +228,8 @@ public class OrcWriter
                 col.childCount++;
                 continue;
             }
-            appendPrimitiveColumn(col.childCount, elementType, col.child, new StringColumn(o.toString()), null, elementType.toString());
+            appendPrimitiveColumn(col.childCount, elementType, col.child,
+                    new StringColumn(o.toString()), eachColumnConf, elementType.toString());
 
             col.childCount++;
         }
@@ -224,8 +241,11 @@ public class OrcWriter
      * @param row the row number in the batch
      * @param recordColumn the record column containing the array value
      * @param col the column vector to append the array value to
+     * @param valueType the value type declared for this column
+     * @param eachColumnConf the configuration of this column
      */
-    private void appendMapValue(int row, Column recordColumn, MapColumnVector col)
+    private void appendMapValue(int row, Column recordColumn, MapColumnVector col,
+            SupportHiveDataType valueType, Configuration eachColumnConf)
     {
         // assume the column is a map of V or the string of map of V
         // {key1:value1,key2:value2}
@@ -250,7 +270,8 @@ public class OrcWriter
             }
             else {
                 col.values.isNull[col.childCount] = false;
-                appendPrimitiveColumn(col.childCount, valueType, mapValueVector, new StringColumn(value.toString()), null, valueType.toString());
+                appendPrimitiveColumn(col.childCount, valueType, mapValueVector,
+                        new StringColumn(value.toString()), eachColumnConf, valueType.toString());
             }
             col.childCount++;
         }
@@ -273,7 +294,7 @@ public class OrcWriter
         }
         else if (colType == Column.Type.DATE) {
             if (((DateColumn) column).getSubType() == DateColumn.DateType.TIME) {
-                buffer = formatTimeWithNanos(column).getBytes(StandardCharsets.UTF_8);
+                buffer = formatTimeWithNanos(column, columnTimeZone).getBytes(StandardCharsets.UTF_8);
             }
             else {
                 buffer = DATE_FORMAT.get().format(column.asDate()).getBytes(StandardCharsets.UTF_8);
@@ -297,7 +318,8 @@ public class OrcWriter
         String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase();
         int batchSize = config.getInt(Key.BATCH_SIZE, DEFAULT_BATCH_SIZE);
 
-        TypeDescription schema = buildOrcSchema(columns);
+        OrcLayout layout = buildOrcSchema(columns);
+        TypeDescription schema = layout.schema();
         Path filePath = new Path(fileName);
         org.apache.orc.OrcFile.WriterOptions writerOptions =
                 buildWriterOptions(conf, config, schema, columns, compress);
@@ -309,7 +331,7 @@ public class OrcWriter
 
             while ((record = lineReceiver.getFromReader()) != null) {
                 int row = batch.size++;
-                setRow(batch, row, record, columns, taskPluginCollector);
+                setRow(batch, row, record, columns, taskPluginCollector, layout);
 
                 if (batch.size == batch.getMaxSize()) {
                     writer.addRowBatch(batch);
@@ -333,15 +355,19 @@ public class OrcWriter
      * Builds the ORC schema based on the provided column configurations.
      *
      * @param columns the list of column configurations
-     * @return the ORC schema as a TypeDescription object
+     * @return the ORC schema along with the collection types resolved per column
      */
-    private TypeDescription buildOrcSchema(List<Configuration> columns)
+    private OrcLayout buildOrcSchema(List<Configuration> columns)
     {
         TypeDescription schema = TypeDescription.createStruct().setAttribute("creator", "addax");
+        List<SupportHiveDataType> elementTypes = new ArrayList<>(columns.size());
+        List<SupportHiveDataType> mapValueTypes = new ArrayList<>(columns.size());
 
         for (Configuration column : columns) {
             String typeName = column.getString(Key.TYPE).toLowerCase();
             String fieldName = column.getString(Key.NAME);
+            SupportHiveDataType elementType = null;
+            SupportHiveDataType mapValueType = null;
 
             if ("decimal".equalsIgnoreCase(typeName)) {
                 int precision = column.getInt(Key.PRECISION, Constant.DEFAULT_DECIMAL_MAX_PRECISION);
@@ -349,9 +375,9 @@ public class OrcWriter
                 schema.addField(fieldName, TypeDescription.createDecimal().withScale(scale).withPrecision(precision));
             }
             else if (typeName.startsWith("array")) {
-                String elementType = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
-                TypeDescription elementTypeDesc = TypeDescription.fromString(elementType);
-                this.elementType = SupportHiveDataType.valueOf(elementType.toUpperCase());
+                String elementTypeName = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
+                TypeDescription elementTypeDesc = TypeDescription.fromString(elementTypeName);
+                elementType = SupportHiveDataType.valueOf(elementTypeName.toUpperCase());
                 schema.addField(fieldName, TypeDescription.createList(elementTypeDesc));
             }
             else if (typeName.startsWith("map")) {
@@ -359,14 +385,18 @@ public class OrcWriter
                 String[] keyValueTypes = keyValueType.split(",");
                 TypeDescription keyTypeDesc = TypeDescription.fromString(keyValueTypes[0]);
                 TypeDescription valueTypeDesc = TypeDescription.fromString(keyValueTypes[1].trim());
-                this.valueType = SupportHiveDataType.valueOf(keyValueTypes[1].trim().toUpperCase());
+                mapValueType = SupportHiveDataType.valueOf(keyValueTypes[1].trim().toUpperCase());
                 schema.addField(fieldName, TypeDescription.createMap(keyTypeDesc, valueTypeDesc));
             }
             else {
                 schema.addField(fieldName, TypeDescription.fromString(typeName));
             }
+
+            // stay aligned with the configured column order, setRow indexes these by column
+            elementTypes.add(elementType);
+            mapValueTypes.add(mapValueType);
         }
-        return schema;
+        return new OrcLayout(schema, elementTypes, mapValueTypes);
     }
 
     private org.apache.orc.OrcFile.WriterOptions buildWriterOptions(org.apache.hadoop.conf.Configuration hadoopConf,

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
@@ -220,9 +220,25 @@ public class ParquetWriter
                 group.append(colName, decimalToBinary(column.asString(), scale));
             }
             case TIMESTAMP -> group.append(colName, tsToBinary(column.asTimestamp()));
-            case DATE -> group.append(colName, (int) Math.round(column.asLong() * 1.0 / MILLIS_PER_DAY));
-            default -> group.append(colName, formatTimeWithNanos(column));
+            case DATE -> group.append(colName, dateToEpochDay(column));
+            default -> group.append(colName, formatTimeWithNanos(column, columnTimeZone));
         }
+    }
+
+    /**
+     * Converts a DATE column to the number of days since the unix epoch.
+     * <p>
+     * A DATE arrives as an instant at local midnight, so it has to be read as a calendar date.
+     * Dividing the raw millis by {@code MILLIS_PER_DAY} instead counts elapsed days since the
+     * epoch and lands a day early in any zone east of UTC, which also disagreed with
+     * {@link OrcWriter} for the very same job configuration.
+     *
+     * @param column the column holding the date value
+     * @return the epoch day of the date
+     */
+    private static int dateToEpochDay(Column column)
+    {
+        return (int) new java.sql.Date(column.asLong()).toLocalDate().toEpochDay();
     }
 
     /**
@@ -320,8 +336,11 @@ public class ParquetWriter
     private Binary tsToBinary(Timestamp ts)
     {
         long millis = ts.getTime();
-        int julianDays = (int) (millis / MILLIS_PER_DAY) + JULIAN_EPOCH_OFFSET_DAYS;
-        long nanosOfDay = (millis % MILLIS_PER_DAY) * NANOS_PER_MILLISECOND + (ts.getNanos() % (int) NANOS_PER_MILLISECOND);
+        // floorDiv/floorMod rather than plain division: truncation rounds towards zero, so any
+        // pre-1970 value would leave a negative time-of-day inside the 12-byte INT96 buffer
+        int julianDays = (int) Math.floorDiv(millis, MILLIS_PER_DAY) + JULIAN_EPOCH_OFFSET_DAYS;
+        long nanosOfDay = Math.floorMod(millis, MILLIS_PER_DAY) * NANOS_PER_MILLISECOND
+                + ts.getNanos() % NANOS_PER_MILLISECOND;
 
         // Write INT96 timestamp
         byte[] timestampBuffer = new byte[12];

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
@@ -107,7 +107,7 @@ public class TextWriter
     }
 
     /** Transportonerecord. */
-    public static MutablePair<Text, Boolean> transportOneRecord(
+    public MutablePair<Text, Boolean> transportOneRecord(
             Record record, char fieldDelimiter, List<Configuration> columnsConfiguration, TaskPluginCollector taskPluginCollector)
     {
         MutablePair<List<Object>, Boolean> transportResultList = transportOneRecord(record, columnsConfiguration, taskPluginCollector);
@@ -120,7 +120,7 @@ public class TextWriter
     }
 
     /** Transportonerecord. */
-    public static MutablePair<List<Object>, Boolean> transportOneRecord(
+    public MutablePair<List<Object>, Boolean> transportOneRecord(
             Record record, List<Configuration> columnsConfiguration,
             TaskPluginCollector taskPluginCollector)
     {
@@ -145,7 +145,7 @@ public class TextWriter
                             case BIGINT -> recordList.add(column.asLong());
                             case FLOAT -> recordList.add(Float.valueOf(rowData));
                             case DOUBLE -> recordList.add(column.asDouble());
-                            case STRING, VARCHAR, CHAR -> recordList.add(formatTimeWithNanos(column));
+                            case STRING, VARCHAR, CHAR -> recordList.add(formatTimeWithNanos(column, columnTimeZone));
                             case DECIMAL -> recordList.add(HiveDecimal.create(column.asBigDecimal()));
                             case BOOLEAN -> recordList.add(column.asBoolean());
                             case DATE -> recordList.add(org.apache.hadoop.hive.common.type.Date.valueOf(column.asString()));


### PR DESCRIPTION
## Summary

Fixes several value-encoding defects in the HDFS writer so that what it stores matches the source
record and agrees across the three output formats (`text`, `orc`, `parquet`), plus one missing
reader-side dependency that made LZ4 output unreadable.

Every defect below was reproduced by driving the real writer classes against a synthetic
`RecordReceiver` with `defaultFS=file:///`, then reading the produced file back.

## Related Issue(s)

Relates to #1531 (the LZ4 fix made writing work, but not reading).

## What type of change is this?

- [x] Bugfix

## Changes

**`plugin/writer/hdfswriter`**

- `ParquetWriter.tsToBinary`: use `Math.floorDiv` / `Math.floorMod` on the epoch millis. Truncating
  division rounds towards zero, so any pre-1970 timestamp encoded a *negative* nanos-of-day into
  the 12-byte INT96 buffer.
- `ParquetWriter.dateToEpochDay`: convert a DATE column through
  `java.sql.Date.toLocalDate().toEpochDay()`, the same expression `OrcWriter` uses. The previous
  `Math.round(millis / 86400000)` counts elapsed days since the epoch, which is a day early in any
  zone east of UTC.
- `OrcWriter`: the array element type and map value type were writer-level fields overwritten while
  building the schema, so every ARRAY/MAP column was encoded with the *last* collection column's
  type. They are now resolved per column into an `OrcLayout` record and looked up by column index.
  The collection writers also stop receiving a `null` column config (`ARRAY<DECIMAL>` used to NPE).
- `HdfsHelper.formatTimeWithNanos`: render the time-of-day in `common.column.timeZone` (the zone
  `ColumnCast`/`Column.asString()` already use) instead of UTC, and use `floorMod` so pre-1970
  values no longer throw `DateTimeException`.
- `TextWriter.transportOneRecord`: changed from `static` to instance methods so they can reach the
  resolved time zone. No other caller exists in the repository.

**`plugin/reader/hdfsreader`**

- Declare `org.lz4:lz4-java`, mirroring the `hdfswriter`/`s3writer` entries. `hadoop-common`
  declares it `provided`, so the read side had no LZ4 implementation at all.

## Motivation and Context

`hdfswriter` is the most-used writer plugin in the project, and these defects were silent: the job
reported success while writing values that were wrong, or while producing a different logical type
depending on the configured `fileType`. The concrete failure modes were:

- A pre-1970 TIMESTAMP written to parquet decodes to garbage in Hive/Spark, while the ORC writer
  encodes the same value correctly.
- The same DATE job writes two different calendar days depending on `fileType`.
- A table with two ARRAY columns of different element types aborts with `ClassCastException` —
  the collection types are not per-column.
- A TIME value is written one UTC offset away from every other rendering of it.
- `compress=LZ4` parquet can be written but not read back (`NoClassDefFoundError:
  net/jpountz/lz4/LZ4Factory`).

## How has this been tested?

No automated tests were added; the project does not carry unit tests and these were verified
manually end to end.

1. Build: `mvn clean package -T1C -DskipTests` — BUILD SUCCESS.
2. Round-trip the writers directly against `defaultFS=file:///` with hand-built `DefaultRecord`s,
   then read the produced file back and assert on the decoded values:

   | Check | Before | After |
   | --- | --- | --- |
   | parquet INT96 for `1960-01-01`, `1969-12-31 10:00` | negative `nanosOfDay`, decodes to garbage | matches the canonical value derived from `Instant` |
   | parquet INT96 for a post-1970 timestamp | correct | unchanged |
   | DATE `2026-01-15` with `-Duser.timezone=Pacific/Auckland` | `20467` (ORC: `20468`) | both formats `20468` |
   | TIME `10:00:00.5` with `common.column.timeZone=GMT+8`, JVM in Auckland | `02:00:00.500`, disagrees with `asString()` | `10:00:00.500`, matches `asString()`, in both ORC and parquet |
   | TIME with negative millis | `DateTimeException` | format rendered normally |
   | ORC with `array<string>` + `array<bigint>` + repeats | `ClassCastException: BytesColumnVector cannot be cast to LongColumnVector` | schema and all values read back correctly, 0 dirty records |
   | LZ4 parquet written by hdfswriter, read with the hdfsreader classpath only | `NoClassDefFoundError: net/jpountz/lz4/LZ4Factory` | reads back correctly |

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable). — the project carries no unit tests; see the manual matrix above.
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — not needed.
- [ ] I updated CHANGELOG.md when appropriate. — no CHANGELOG in the repo.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

`hdfswriter` now encodes dates, timestamps, times and collection columns consistently across
`text`, `orc` and `parquet`. Pre-1970 timestamps, DATE values in zones east of UTC, TIME values with
a configured `common.column.timeZone`, and tables with more than one ARRAY/MAP column were
previously written incorrectly or aborted the job. `hdfsreader` can now read LZ4-compressed files
again.

## Breaking changes / Migration

None. Jobs that already produced correct output are unaffected: the post-1970 parquet INT96
encoding and the post-1970 TIME path are byte-for-byte unchanged, and DATE values that happened to
be correct under UTC keep the same value. Output written by earlier versions of the affected paths
should be re-generated.

## Additional context

One adjacent behaviour was deliberately left as is: `formatTimeWithNanos` derives the sub-second
part from the millisecond field of the raw value plus the sub-millisecond remainder of `getNanos()`,
whereas `CommonRdbmsWriter` treats `getNanos()` as the full nano-of-second. These differ only for a
driver whose `getTime()` does not carry the fractional seconds. Changing it would need a concrete
driver to reproduce against, so it is not part of this PR.
