### PR TITLE
fix(plugin-hdfswriter): harden failure paths, type handling and parameters

### DIFF
--- a/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/AddaxGen.java
+++ b/lib/addax-gen/src/main/java/com/wgzhao/addax/gen/AddaxGen.java
@@ -371,8 +371,8 @@ public class AddaxGen
         }
 
         // bloom filters are not generated in v1; drop the template's sample columns
-        parameter.remove("bloom.filter.columns");
-        parameter.remove("bloom.filter.fpp");
+        parameter.remove("bloomColumns");
+        parameter.remove("bloomFpp");
     }
 
     /** Fills connection, credentials, columns and splitPk into a JDBC plugin template. */

--- a/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
+++ b/lib/addax-storage/src/main/java/com/wgzhao/addax/storage/writer/StorageWriterUtil.java
@@ -118,14 +118,16 @@ public final class StorageWriterUtil
      */
     private static void validateWriteMode(Configuration writerConfiguration)
     {
-        String writeMode = writerConfiguration.getNecessaryValue(Key.WRITE_MODE, REQUIRED_VALUE);
-        writeMode = writeMode.trim();
-        if (!SUPPORTED_WRITE_MODES.contains(writeMode)) {
-            throw AddaxException.illegalConfigValue(Key.WRITE_MODE, writeMode,
-                    "valid write modes " + String.join(",", SUPPORTED_WRITE_MODES));
-        }
-        writerConfiguration.set(Key.WRITE_MODE, writeMode);
-        LOG.debug("Validated write mode: {}", writeMode);
+        String writeMode = writerConfiguration.getNecessaryValue(Key.WRITE_MODE, REQUIRED_VALUE).trim();
+        // match case-insensitively but store the canonical spelling: the writers compare the
+        // value literally, so a job that spelled it "NONCONFLICT" used to run and now aborts
+        String canonicalMode = SUPPORTED_WRITE_MODES.stream()
+                .filter(mode -> mode.equalsIgnoreCase(writeMode))
+                .findFirst()
+                .orElseThrow(() -> AddaxException.illegalConfigValue(Key.WRITE_MODE, writeMode,
+                        "valid write modes " + String.join(",", SUPPORTED_WRITE_MODES)));
+        writerConfiguration.set(Key.WRITE_MODE, canonicalMode);
+        LOG.debug("Validated write mode: {}", canonicalMode);
     }
 
     /**

--- a/plugin/reader/hdfsreader/pom.xml
+++ b/plugin/reader/hdfsreader/pom.xml
@@ -105,6 +105,13 @@
             <artifactId>parquet-hadoop-bundle</artifactId>
         </dependency>
 
+        <!-- hadoop-common declares lz4-java as provided (it ships it in its own distro),
+             so supply it explicitly or reading LZ4 parquet/text fails with NoClassDefFoundError -->
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
@@ -50,6 +50,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.wgzhao.addax.core.base.Key.HAVE_KERBEROS;
@@ -73,6 +74,16 @@ public class HdfsHelper
     protected org.apache.hadoop.conf.Configuration hadoopConf = null;
     private static final double DEFAULT_BLOOM_FILTER_FPP = 0.05d;
 
+    // Column rendering has to agree with Column.asString(), which formats in this same zone,
+    // otherwise a TIME value is written one offset away from every other representation of it
+    private static final String COLUMN_TIME_ZONE = "common.column.timeZone";
+    private static final String DEFAULT_COLUMN_TIME_ZONE = "GMT+8";
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+    private static final long NANOS_PER_MILLISECOND = 1_000_000L;
+
+    /** The zone used to render DATE/TIME columns. */
+    protected TimeZone columnTimeZone = TimeZone.getTimeZone(DEFAULT_COLUMN_TIME_ZONE);
+
     record BloomFilterConfig(String columns, double fpp)
     {
     }
@@ -81,6 +92,8 @@ public class HdfsHelper
     {
         hadoopConf = new org.apache.hadoop.conf.Configuration();
         String defaultFS = taskConfig.getString(Key.DEFAULT_FS);
+        this.columnTimeZone = TimeZone.getTimeZone(
+                taskConfig.getString(COLUMN_TIME_ZONE, DEFAULT_COLUMN_TIME_ZONE));
         Configuration hadoopSiteParams = taskConfig.getConfiguration(Key.HADOOP_CONFIG);
         JSONObject hadoopSiteParamsAsJsonObject = JSON.parseObject(taskConfig.getString(Key.HADOOP_CONFIG));
         if (null != hadoopSiteParams) {
@@ -376,15 +389,19 @@ public class HdfsHelper
      * When nanos is zero, delegates to the default {@code column.asString()} ({@code HH:mm:ss}).
      *
      * @param column the input column to format
+     * @param timeZone the zone the time-of-day is expressed in
      * @return formatted time string with full precision when applicable
      */
-    protected static String formatTimeWithNanos(Column column)
+    protected static String formatTimeWithNanos(Column column, TimeZone timeZone)
     {
         if (column.getType() == Column.Type.DATE && ((DateColumn) column).getSubType() == DateColumn.DateType.TIME) {
             long nanos = ((DateColumn) column).getNanos();
             if (nanos > 0) {
                 long timeMs = (Long) column.getRawData();
-                long totalNanosOfDay = (timeMs % 86_400_000L) * 1_000_000L + (nanos % 1_000_000L);
+                // The raw value is an instant, not a wall clock reading: apply the same zone the
+                // default asString() path uses, and floorMod so pre-1970 values stay in range
+                long millisOfDay = Math.floorMod(timeMs + timeZone.getOffset(timeMs), MILLIS_PER_DAY);
+                long totalNanosOfDay = millisOfDay * NANOS_PER_MILLISECOND + nanos % NANOS_PER_MILLISECOND;
                 return LocalTime.ofNanoOfDay(totalNanosOfDay).toString();
             }
         }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsHelper.java
@@ -32,9 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.mapred.JobConf;
@@ -48,6 +46,8 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
@@ -207,27 +207,60 @@ public class HdfsHelper
         return isDir;
     }
 
+    /**
+     * Delete one file, failing loudly when the filesystem reports that it could not.
+     *
+     * @param path the file to delete
+     * @throws IOException if the deletion was refused
+     */
+    private void remove(Path path, boolean recursive)
+            throws IOException
+    {
+        if (!fileSystem.delete(path, recursive)) {
+            throw new IOException(String.format("Failed to delete [%s]", path));
+        }
+    }
+
     /** Deletefilesfromdir. */
     public void deleteFilesFromDir(Path dir, boolean skipTrash)
     {
         try {
-            final RemoteIterator<LocatedFileStatus> files = fileSystem.listFiles(dir, false);
+            final Trash trash;
             if (skipTrash) {
-                while (files.hasNext()) {
-                    final LocatedFileStatus next = files.next();
-                    LOG.info("Delete the file [{}]", next.getPath());
-                    fileSystem.delete(next.getPath(), false);
-                }
+                trash = null;
             }
             else {
                 if (hadoopConf.getInt(CommonConfigurationKeys.FS_TRASH_INTERVAL_KEY, 0) == 0) {
                     hadoopConf.set(CommonConfigurationKeys.FS_TRASH_INTERVAL_KEY, "10080"); // 7 days
                 }
-                final Trash trash = new Trash(hadoopConf);
-                while (files.hasNext()) {
-                    final LocatedFileStatus next = files.next();
-                    LOG.info("Move the file [{}] to Trash", next.getPath());
-                    trash.moveToTrash(next.getPath());
+                trash = new Trash(hadoopConf);
+            }
+
+            // listStatus rather than listFiles(recursive=false): an overwrite has to clear the
+            // sub-directories of a partition tree too, and a non-recursive file listing left them
+            // and their contents behind next to the newly written files
+            for (FileStatus entry : fileSystem.listStatus(dir)) {
+                Path entryPath = entry.getPath();
+
+                // hidden entries are this plugin's own staging directory, and the readers skip
+                // them as well, so they are not part of the data being replaced
+                if (entryPath.getName().startsWith(".")) {
+                    continue;
+                }
+
+                if (trash == null) {
+                    LOG.info("Delete the [{}]", entryPath);
+                    remove(entryPath, entry.isDirectory());
+                }
+                else {
+                    LOG.info("Move the [{}] to Trash", entryPath);
+                    // the call reports failure by returning false rather than by throwing, and the
+                    // caller writes the new files right afterwards, so an unchecked false would
+                    // silently leave the previous run's data in place
+                    if (!trash.moveToTrash(entryPath)) {
+                        throw AddaxException.asAddaxException(IO_ERROR,
+                                String.format("Failed to move [%s] to Trash", entryPath));
+                    }
                 }
             }
         }
@@ -280,8 +313,21 @@ public class HdfsHelper
             final FileStatus[] fileStatuses = fileSystem.listStatus(sourceDir);
             for (FileStatus file : fileStatuses) {
                 if (file.isFile() && file.getLen() > 0) {
-                    LOG.info("Begin to move the file [{}] to [{}].", file.getPath(), targetDir);
-                    fileSystem.rename(file.getPath(), new Path(targetDir, file.getPath().getName()));
+                    Path dest = new Path(targetDir, file.getPath().getName());
+                    // rename() reports several failures by returning false instead of throwing on
+                    // HDFS, but on the local and other FileSystem implementations it silently
+                    // replaces an existing name, and the caller deletes the staging directory
+                    // right afterwards either way
+                    if (fileSystem.exists(dest)) {
+                        throw AddaxException.asAddaxException(IO_ERROR, String.format(
+                                "Refusing to move [%s]: the destination [%s] already exists.",
+                                file.getPath(), dest));
+                    }
+                    LOG.info("Begin to move the file [{}] to [{}].", file.getPath(), dest);
+                    if (!fileSystem.rename(file.getPath(), dest)) {
+                        throw AddaxException.asAddaxException(IO_ERROR,
+                                String.format("Failed to move the file [%s] to [%s]", file.getPath(), dest));
+                    }
                 }
             }
         }
@@ -303,19 +349,36 @@ public class HdfsHelper
         }
     }
 
+    /**
+     * The codecs {@link #getCompressCodec} can instantiate, so that validation and execution
+     * consult one list instead of two that have to be kept in sync by hand.
+     * <p>
+     * LZO is absent because writing it needs the hadoop-lzo native library, and ZSTD because
+     * hadoop's {@code ZStandardCodec} is built on native libhadoop rather than the zstd-jni jar:
+     * both fail at task runtime with "native library not available" if they are let through.
+     */
+    private static final Map<String, Class<? extends CompressionCodec>> COMPRESS_CODECS = Map.of(
+            "GZIP", org.apache.hadoop.io.compress.GzipCodec.class,
+            "BZIP2", org.apache.hadoop.io.compress.BZip2Codec.class,
+            "SNAPPY", org.apache.hadoop.io.compress.SnappyCodec.class,
+            "LZ4", org.apache.hadoop.io.compress.Lz4Codec.class,
+            "DEFLATE", org.apache.hadoop.io.compress.DeflateCodec.class,
+            "ZLIB", org.apache.hadoop.io.compress.DeflateCodec.class);
+
+    /** The names of the codecs the text writer can emit. */
+    public static Set<String> compressCodecNames()
+    {
+        return COMPRESS_CODECS.keySet();
+    }
+
     public Class<? extends CompressionCodec> getCompressCodec(String compress)
     {
-        compress = compress.toUpperCase();
-        Class<? extends CompressionCodec> codecClass = switch (compress) {
-            case "GZIP" -> org.apache.hadoop.io.compress.GzipCodec.class;
-            case "BZIP2" -> org.apache.hadoop.io.compress.BZip2Codec.class;
-            case "SNAPPY" -> org.apache.hadoop.io.compress.SnappyCodec.class;
-            case "LZ4" -> org.apache.hadoop.io.compress.Lz4Codec.class;
-            case "ZSTD" -> org.apache.hadoop.io.compress.ZStandardCodec.class;
-            case "DEFLATE", "ZLIB" -> org.apache.hadoop.io.compress.DeflateCodec.class;
-            default -> throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
-                    String.format("The compress mode [%s] is unsupported yet.", compress));
-        };
+        String normalized = compress.trim().toUpperCase(Locale.ROOT);
+        Class<? extends CompressionCodec> codecClass = COMPRESS_CODECS.get(normalized);
+        if (codecClass == null) {
+            throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
+                    String.format("The compress mode [%s] is unsupported yet.", normalized));
+        }
         return codecClass;
     }
 

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/HdfsWriter.java
@@ -79,10 +79,6 @@ public class HdfsWriter
         /** Support format. */
         public static final Set<String> SUPPORT_FORMAT = Set.of("ORC", "PARQUET", "TEXT");
 
-        // Codecs the text writer can emit; keep in sync with HdfsHelper.getCompressCodec
-        private static final Set<String> TEXT_COMPRESS_CODECS = Set.of(
-                "GZIP", "BZIP2", "SNAPPY", "LZ4", "ZSTD", "DEFLATE", "ZLIB");
-
         // Create record for decimal configuration
         private record DecimalConfig(int precision, int scale) {}
 
@@ -172,7 +168,11 @@ public class HdfsWriter
                             String.format("The item path you configured [%s] is exists ,but it is not directory", path));
                 }
 
-                Path[] existFilePaths = hdfsHelper.hdfsDirList(path);
+                // staging directories (".<uuid>") are this plugin's own leftovers rather than
+                // data, and the reader side skips hidden entries too
+                Path[] existFilePaths = Arrays.stream(hdfsHelper.hdfsDirList(path))
+                        .filter(existPath -> !existPath.getName().startsWith("."))
+                        .toArray(Path[]::new);
 
                 boolean isExistFile = existFilePaths.length > 0;
                 if ("append".equals(writeMode)) {
@@ -210,7 +210,9 @@ public class HdfsWriter
         @Override
         public void post()
         {
-            if ("overwrite".equals(writeMode)) {
+            // truncate carries the same meaning here as overwrite: the new files always get
+            // freshly generated names, so there is nothing to preserve from the previous run
+            if ("overwrite".equals(writeMode) || "truncate".equals(writeMode)) {
                 hdfsHelper.deleteFilesFromDir(new Path(path), this.skipTrash);
             }
 
@@ -232,6 +234,16 @@ public class HdfsWriter
         @Override
         public void destroy()
         {
+            // post() runs only on the success path, so without this a failed job would leave the
+            // staging directory - and the partial files inside it - in the table directory
+            if (tmpStorePath != null) {
+                try {
+                    hdfsHelper.deleteDir(new Path(tmpStorePath));
+                }
+                catch (Exception e) {
+                    LOG.warn("Failed to clean the temporary directory [{}]: {}", tmpStorePath, e.getMessage());
+                }
+            }
             hdfsHelper.closeFileSystem();
         }
 
@@ -243,22 +255,26 @@ public class HdfsWriter
             List<Configuration> writerSplitConfigs = new ArrayList<>();
             String filePrefix = fileName;
 
-            Set<String> allFiles = Arrays.stream(hdfsHelper.hdfsDirList(path)).map(Path::toString).collect(Collectors.toSet());
+            // compare bare file names: post() moves each staging file into <path> under exactly
+            // the name built below, while hdfsDirList returns fully qualified paths
+            Set<String> existingFileNames = Arrays.stream(hdfsHelper.hdfsDirList(path))
+                    .map(Path::getName)
+                    .collect(Collectors.toSet());
 
             String fileType = this.writerSliceConfig.getString(Key.FILE_TYPE, "txt").toLowerCase();
-            String tmpFullFileName;
-            String endFullFileName;
             for (int i = 0; i < mandatoryNumber; i++) {
-                // handle same file name
                 Configuration splitTaskConfig = this.writerSliceConfig.clone();
 
+                // one middle name for both the staging file and the collision check; a second,
+                // independently random name would be tested against the destination instead of
+                // the file that is actually moved there, which defeats the guard
+                String taskFileName;
                 do {
-                    tmpFullFileName = String.format("%s/%s_%s.%s", tmpStorePath, filePrefix, FileHelper.generateFileMiddleName(), fileType);
-                    endFullFileName = String.format("%s/%s_%s.%s", path, filePrefix, FileHelper.generateFileMiddleName(), fileType);
+                    taskFileName = String.format("%s_%s.%s", filePrefix, FileHelper.generateFileMiddleName(), fileType);
                 }
-                while (allFiles.contains(endFullFileName));
-                allFiles.add(endFullFileName);
+                while (!existingFileNames.add(taskFileName));
 
+                String tmpFullFileName = String.format("%s/%s", tmpStorePath, taskFileName);
                 splitTaskConfig.set(Key.FILE_NAME, tmpFullFileName);
 
                 LOG.info("The split wrote files :[{}]", tmpFullFileName);
@@ -419,14 +435,15 @@ public class HdfsWriter
                     }
                 }
                 case "TEXT" -> {
-                    // Codecs mirror HdfsHelper.getCompressCodec; LZO is absent because writing it
-                    // needs the hadoop-lzo native library, which this project does not bundle.
-                    if (!"NONE".equals(compress) && !TEXT_COMPRESS_CODECS.contains(compress)) {
+                    // one list for both validation and lookup, so a codec can never pass here and
+                    // then fail inside the task after the data has already been read
+                    Set<String> codecs = HdfsHelper.compressCodecNames();
+                    if (!"NONE".equals(compress) && !codecs.contains(compress)) {
                         throw AddaxException.asAddaxException(ILLEGAL_VALUE,
                                 """
                                         The TEXT format only supports NONE, [%s] compression.
-                                        Your configure [%s] is unsupported yet (LZO writing requires the hadoop-lzo native library).
-                                        """.formatted(String.join(", ", TEXT_COMPRESS_CODECS), compress));
+                                        Your configure [%s] is unsupported yet.
+                                        """.formatted(String.join(", ", codecs), compress));
                     }
                 }
             }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
@@ -56,6 +56,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import static com.wgzhao.addax.core.spi.ErrorCode.IO_ERROR;
 import static com.wgzhao.addax.core.spi.ErrorCode.NOT_SUPPORT_TYPE;
@@ -108,7 +109,7 @@ public class OrcWriter
     {
         for (int i = 0; i < columns.size(); i++) {
             Configuration eachColumnConf = columns.get(i);
-            String type = eachColumnConf.getString(Key.TYPE).trim().toUpperCase();
+            String type = eachColumnConf.getString(Key.TYPE).trim().toUpperCase(Locale.ROOT);
             ColumnVector col = batch.cols[i];
 
             // Handle null values
@@ -119,19 +120,21 @@ public class OrcWriter
                 continue;
             }
 
-            if (type.startsWith("ARRAY")) {
-                appendArrayValue(row, recordColumn, (ListColumnVector) col,
-                        layout.elementTypes().get(i), eachColumnConf);
-                continue;
-            }
-
-            if (type.startsWith("MAP")) {
-                appendMapValue(row, recordColumn, (MapColumnVector) col,
-                        layout.mapValueTypes().get(i), eachColumnConf);
-                continue;
-            }
-
+            // the collection branches share the try below as well: outside it their failures
+            // escaped as a raw ClassCastException from the middle of a batch
             try {
+                if (type.startsWith("ARRAY")) {
+                    appendArrayValue(row, recordColumn, (ListColumnVector) col,
+                            layout.elementTypes().get(i), eachColumnConf);
+                    continue;
+                }
+
+                if (type.startsWith("MAP")) {
+                    appendMapValue(row, recordColumn, (MapColumnVector) col,
+                            layout.mapValueTypes().get(i), eachColumnConf);
+                    continue;
+                }
+
                 // Determine column type
                 SupportHiveDataType columnType;
                 if (type.startsWith("DECIMAL")) {
@@ -139,7 +142,7 @@ public class OrcWriter
                 }
                 else {
                     try {
-                        columnType = SupportHiveDataType.valueOf(type);
+                        columnType = SupportHiveDataType.of(type);
                     }
                     catch (IllegalArgumentException e) {
                         throw AddaxException.asAddaxException(
@@ -254,7 +257,7 @@ public class OrcWriter
         // convert the string to a map of V
         col.offsets[row] = col.childCount;
         col.lengths[row] = jsonObject.size();
-        // The key in map must be a string type
+        // buildOrcSchema rejects every other key type, so this cast cannot fail here
         BytesColumnVector mapKeyVector = (BytesColumnVector) col.keys;
         ColumnVector mapValueVector = col.values;
         for (Map.Entry<String, Object> entry : jsonObject.entrySet()) {
@@ -315,7 +318,7 @@ public class OrcWriter
             TaskPluginCollector taskPluginCollector)
     {
         List<Configuration> columns = config.getListConfiguration(Key.COLUMN);
-        String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase();
+        String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase(Locale.ROOT).trim();
         int batchSize = config.getInt(Key.BATCH_SIZE, DEFAULT_BATCH_SIZE);
 
         OrcLayout layout = buildOrcSchema(columns);
@@ -346,8 +349,49 @@ public class OrcWriter
         }
         catch (IOException e) {
             logger.error("IO exception occurred while writing file [{}]: {}", fileName, e.getMessage());
-            deleteDir(filePath.getParent());
+            // no per-task cleanup here: the parent is the staging directory shared by every split
+            // task, and Job.destroy() removes the whole staging directory on failure anyway
             throw AddaxException.asAddaxException(IO_ERROR, e);
+        }
+    }
+
+    /**
+     * Translate a configured type into the spelling ORC's parser understands.
+     * <p>
+     * The configuration accepts the SQL aliases ({@code integer}, {@code long}) that the rest of
+     * the plugin also accepts, but {@code TypeDescription.fromString} only knows {@code int} and
+     * {@code bigint} and aborted the task before a single record was read.
+     *
+     * @param type the configured type, lower case and trimmed
+     * @return the ORC type name
+     */
+    private static String toOrcTypeName(String type)
+    {
+        return switch (type) {
+            case "integer" -> "int";
+            case "long" -> "bigint";
+            default -> type;
+        };
+    }
+
+    /**
+     * Reject a map key type the writer cannot produce.
+     * <p>
+     * The key is always read out of a JSON object, so it is a string, and {@code appendMapValue}
+     * writes it through a bytes vector. Any other key type used to be accepted here and then fail
+     * with a ClassCastException in the middle of a batch, after the file had been opened.
+     *
+     * @param fieldName the field being built, for the error message
+     * @param keyType the configured key type
+     */
+    private static void validateMapKeyType(String fieldName, String keyType)
+    {
+        SupportHiveDataType type = SupportHiveDataType.of(keyType);
+        if (type != SupportHiveDataType.STRING && type != SupportHiveDataType.VARCHAR
+                && type != SupportHiveDataType.CHAR) {
+            throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
+                    String.format("The key of the map field [%s] must be a string type, but got [%s].",
+                            fieldName, keyType.trim()));
         }
     }
 
@@ -364,7 +408,7 @@ public class OrcWriter
         List<SupportHiveDataType> mapValueTypes = new ArrayList<>(columns.size());
 
         for (Configuration column : columns) {
-            String typeName = column.getString(Key.TYPE).toLowerCase();
+            String typeName = column.getString(Key.TYPE).toLowerCase(Locale.ROOT);
             String fieldName = column.getString(Key.NAME);
             SupportHiveDataType elementType = null;
             SupportHiveDataType mapValueType = null;
@@ -375,21 +419,23 @@ public class OrcWriter
                 schema.addField(fieldName, TypeDescription.createDecimal().withScale(scale).withPrecision(precision));
             }
             else if (typeName.startsWith("array")) {
-                String elementTypeName = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
-                TypeDescription elementTypeDesc = TypeDescription.fromString(elementTypeName);
-                elementType = SupportHiveDataType.valueOf(elementTypeName.toUpperCase());
+                String elementTypeName = typeName.substring(typeName.indexOf("<") + 1, typeName.lastIndexOf(">"));
+                TypeDescription elementTypeDesc = TypeDescription.fromString(toOrcTypeName(elementTypeName.trim()));
+                elementType = SupportHiveDataType.of(elementTypeName);
                 schema.addField(fieldName, TypeDescription.createList(elementTypeDesc));
             }
             else if (typeName.startsWith("map")) {
-                String keyValueType = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
-                String[] keyValueTypes = keyValueType.split(",");
-                TypeDescription keyTypeDesc = TypeDescription.fromString(keyValueTypes[0]);
-                TypeDescription valueTypeDesc = TypeDescription.fromString(keyValueTypes[1].trim());
-                mapValueType = SupportHiveDataType.valueOf(keyValueTypes[1].trim().toUpperCase());
+                String keyValueType = typeName.substring(typeName.indexOf("<") + 1, typeName.lastIndexOf(">"));
+                // limit 2: a parameterised value type carries its own comma, e.g. map<string,decimal(10,2)>
+                String[] keyValueTypes = keyValueType.split(",", 2);
+                validateMapKeyType(fieldName, keyValueTypes[0]);
+                TypeDescription keyTypeDesc = TypeDescription.fromString(toOrcTypeName(keyValueTypes[0].trim()));
+                TypeDescription valueTypeDesc = TypeDescription.fromString(toOrcTypeName(keyValueTypes[1].trim()));
+                mapValueType = SupportHiveDataType.of(keyValueTypes[1]);
                 schema.addField(fieldName, TypeDescription.createMap(keyTypeDesc, valueTypeDesc));
             }
             else {
-                schema.addField(fieldName, TypeDescription.fromString(typeName));
+                schema.addField(fieldName, TypeDescription.fromString(toOrcTypeName(typeName.trim())));
             }
 
             // stay aligned with the configured column order, setRow indexes these by column

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/OrcWriter.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -71,10 +72,19 @@ public class OrcWriter
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
     private static final ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT =
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
-    // the type of the element in the array
-    private SupportHiveDataType elementType;
-    // the type of the value in the map
-    private SupportHiveDataType valueType;
+
+    /**
+     * The ORC schema together with the element/value type resolved for every configured column.
+     * <p>
+     * The collection types are held per column instead of as writer state: a table may declare
+     * several ARRAY or MAP columns whose element types differ, and a single field would keep only
+     * the last one parsed and apply it to all of them.
+     */
+    private record OrcLayout(TypeDescription schema,
+            List<SupportHiveDataType> elementTypes,
+            List<SupportHiveDataType> mapValueTypes)
+    {
+    }
 
     /** Orcwriter. */
     public OrcWriter(Configuration conf)
@@ -91,9 +101,10 @@ public class OrcWriter
      * @param record {@link Record}
      * @param columns table columns, {@link List}
      * @param taskPluginCollector {@link TaskPluginCollector}
+     * @param layout the schema and the per-column collection types
      */
     private void setRow(VectorizedRowBatch batch, int row, Record record, List<Configuration> columns,
-            TaskPluginCollector taskPluginCollector)
+            TaskPluginCollector taskPluginCollector, OrcLayout layout)
     {
         for (int i = 0; i < columns.size(); i++) {
             Configuration eachColumnConf = columns.get(i);
@@ -109,12 +120,14 @@ public class OrcWriter
             }
 
             if (type.startsWith("ARRAY")) {
-                appendArrayValue(row, recordColumn, (ListColumnVector) col);
+                appendArrayValue(row, recordColumn, (ListColumnVector) col,
+                        layout.elementTypes().get(i), eachColumnConf);
                 continue;
             }
 
             if (type.startsWith("MAP")) {
-                appendMapValue(row, recordColumn, (MapColumnVector) col);
+                appendMapValue(row, recordColumn, (MapColumnVector) col,
+                        layout.mapValueTypes().get(i), eachColumnConf);
                 continue;
             }
 
@@ -196,8 +209,11 @@ public class OrcWriter
      * @param row the row number in the batch
      * @param recordColumn the record column containing the array value
      * @param col the column vector to append the array value to
+     * @param elementType the element type declared for this column
+     * @param eachColumnConf the configuration of this column
      */
-    private void appendArrayValue(int row, Column recordColumn, ListColumnVector col)
+    private void appendArrayValue(int row, Column recordColumn, ListColumnVector col,
+            SupportHiveDataType elementType, Configuration eachColumnConf)
     {
         // "['value1','value2'] ,convert the string to a list of V
         String arrayString = recordColumn.asString();
@@ -212,7 +228,8 @@ public class OrcWriter
                 col.childCount++;
                 continue;
             }
-            appendPrimitiveColumn(col.childCount, elementType, col.child, new StringColumn(o.toString()), null, elementType.toString());
+            appendPrimitiveColumn(col.childCount, elementType, col.child,
+                    new StringColumn(o.toString()), eachColumnConf, elementType.toString());
 
             col.childCount++;
         }
@@ -224,8 +241,11 @@ public class OrcWriter
      * @param row the row number in the batch
      * @param recordColumn the record column containing the array value
      * @param col the column vector to append the array value to
+     * @param valueType the value type declared for this column
+     * @param eachColumnConf the configuration of this column
      */
-    private void appendMapValue(int row, Column recordColumn, MapColumnVector col)
+    private void appendMapValue(int row, Column recordColumn, MapColumnVector col,
+            SupportHiveDataType valueType, Configuration eachColumnConf)
     {
         // assume the column is a map of V or the string of map of V
         // {key1:value1,key2:value2}
@@ -250,7 +270,8 @@ public class OrcWriter
             }
             else {
                 col.values.isNull[col.childCount] = false;
-                appendPrimitiveColumn(col.childCount, valueType, mapValueVector, new StringColumn(value.toString()), null, valueType.toString());
+                appendPrimitiveColumn(col.childCount, valueType, mapValueVector,
+                        new StringColumn(value.toString()), eachColumnConf, valueType.toString());
             }
             col.childCount++;
         }
@@ -273,7 +294,7 @@ public class OrcWriter
         }
         else if (colType == Column.Type.DATE) {
             if (((DateColumn) column).getSubType() == DateColumn.DateType.TIME) {
-                buffer = formatTimeWithNanos(column).getBytes(StandardCharsets.UTF_8);
+                buffer = formatTimeWithNanos(column, columnTimeZone).getBytes(StandardCharsets.UTF_8);
             }
             else {
                 buffer = DATE_FORMAT.get().format(column.asDate()).getBytes(StandardCharsets.UTF_8);
@@ -297,7 +318,8 @@ public class OrcWriter
         String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase();
         int batchSize = config.getInt(Key.BATCH_SIZE, DEFAULT_BATCH_SIZE);
 
-        TypeDescription schema = buildOrcSchema(columns);
+        OrcLayout layout = buildOrcSchema(columns);
+        TypeDescription schema = layout.schema();
         Path filePath = new Path(fileName);
         org.apache.orc.OrcFile.WriterOptions writerOptions =
                 buildWriterOptions(conf, config, schema, columns, compress);
@@ -309,7 +331,7 @@ public class OrcWriter
 
             while ((record = lineReceiver.getFromReader()) != null) {
                 int row = batch.size++;
-                setRow(batch, row, record, columns, taskPluginCollector);
+                setRow(batch, row, record, columns, taskPluginCollector, layout);
 
                 if (batch.size == batch.getMaxSize()) {
                     writer.addRowBatch(batch);
@@ -333,15 +355,19 @@ public class OrcWriter
      * Builds the ORC schema based on the provided column configurations.
      *
      * @param columns the list of column configurations
-     * @return the ORC schema as a TypeDescription object
+     * @return the ORC schema along with the collection types resolved per column
      */
-    private TypeDescription buildOrcSchema(List<Configuration> columns)
+    private OrcLayout buildOrcSchema(List<Configuration> columns)
     {
         TypeDescription schema = TypeDescription.createStruct().setAttribute("creator", "addax");
+        List<SupportHiveDataType> elementTypes = new ArrayList<>(columns.size());
+        List<SupportHiveDataType> mapValueTypes = new ArrayList<>(columns.size());
 
         for (Configuration column : columns) {
             String typeName = column.getString(Key.TYPE).toLowerCase();
             String fieldName = column.getString(Key.NAME);
+            SupportHiveDataType elementType = null;
+            SupportHiveDataType mapValueType = null;
 
             if ("decimal".equalsIgnoreCase(typeName)) {
                 int precision = column.getInt(Key.PRECISION, Constant.DEFAULT_DECIMAL_MAX_PRECISION);
@@ -349,9 +375,9 @@ public class OrcWriter
                 schema.addField(fieldName, TypeDescription.createDecimal().withScale(scale).withPrecision(precision));
             }
             else if (typeName.startsWith("array")) {
-                String elementType = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
-                TypeDescription elementTypeDesc = TypeDescription.fromString(elementType);
-                this.elementType = SupportHiveDataType.valueOf(elementType.toUpperCase());
+                String elementTypeName = typeName.substring(typeName.indexOf("<") + 1, typeName.indexOf(">"));
+                TypeDescription elementTypeDesc = TypeDescription.fromString(elementTypeName);
+                elementType = SupportHiveDataType.valueOf(elementTypeName.toUpperCase());
                 schema.addField(fieldName, TypeDescription.createList(elementTypeDesc));
             }
             else if (typeName.startsWith("map")) {
@@ -359,14 +385,18 @@ public class OrcWriter
                 String[] keyValueTypes = keyValueType.split(",");
                 TypeDescription keyTypeDesc = TypeDescription.fromString(keyValueTypes[0]);
                 TypeDescription valueTypeDesc = TypeDescription.fromString(keyValueTypes[1].trim());
-                this.valueType = SupportHiveDataType.valueOf(keyValueTypes[1].trim().toUpperCase());
+                mapValueType = SupportHiveDataType.valueOf(keyValueTypes[1].trim().toUpperCase());
                 schema.addField(fieldName, TypeDescription.createMap(keyTypeDesc, valueTypeDesc));
             }
             else {
                 schema.addField(fieldName, TypeDescription.fromString(typeName));
             }
+
+            // stay aligned with the configured column order, setRow indexes these by column
+            elementTypes.add(elementType);
+            mapValueTypes.add(mapValueType);
         }
-        return schema;
+        return new OrcLayout(schema, elementTypes, mapValueTypes);
     }
 
     private org.apache.orc.OrcFile.WriterOptions buildWriterOptions(org.apache.hadoop.conf.Configuration hadoopConf,

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
@@ -25,6 +25,7 @@ import com.wgzhao.addax.core.base.Constant;
 import com.wgzhao.addax.core.base.Key;
 import com.wgzhao.addax.core.element.Column;
 import com.wgzhao.addax.core.element.Record;
+import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.plugin.RecordReceiver;
 import com.wgzhao.addax.core.plugin.TaskPluginCollector;
 import com.wgzhao.addax.core.util.Configuration;
@@ -58,8 +59,10 @@ import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import static com.wgzhao.addax.core.spi.ErrorCode.NOT_SUPPORT_TYPE;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 
 /** Parquet Writer. */
@@ -166,6 +169,10 @@ public class ParquetWriter
         Record record;
         while ((record = lineReceiver.getFromReader()) != null) {
             Group group = buildRecord(record, columns, taskPluginCollector, simpleGroupFactory);
+            if (group == null) {
+                // a field could not be converted; the record has been reported as dirty
+                continue;
+            }
             writer.write(group);
         }
     }
@@ -182,8 +189,9 @@ public class ParquetWriter
                 continue;
             }
 
-            String colName = columns.get(i).getString(Key.NAME);
-            String typename = columns.get(i).getString(Key.TYPE).toUpperCase();
+            Configuration columnConfig = columns.get(i);
+            String colName = columnConfig.getString(Key.NAME);
+            String typename = columnConfig.getString(Key.TYPE).trim().toUpperCase(Locale.ROOT);
 
             try {
                 if (typename.startsWith("ARRAY<")) {
@@ -193,13 +201,17 @@ public class ParquetWriter
                     appendMapValue(group, column, colName);
                 }
                 else {
-                    SupportHiveDataType columnType = SupportHiveDataType.valueOf(typename);
-                    appendValueByType(group, column, colName, columnType, columns.get(i));
+                    appendValueByType(group, column, colName, SupportHiveDataType.of(typename), columnConfig);
                 }
             }
-            catch (IllegalArgumentException e) {
-                logger.warn("Convert type [{}] into string", typename);
-                group.append(colName, column.asString());
+            catch (Exception e) {
+                // a value the declared type cannot hold is a dirty record, not a string to stuff
+                // into a typed field: SimpleGroup accepts it and the parquet writer then dies with
+                // a ClassCastException once the group reaches it
+                taskPluginCollector.collectDirtyRecord(record, String.format(
+                        "Type conversion error: target field type: [%s], field value: [%s], error: %s",
+                        columnConfig.getString(Key.TYPE), column.getRawData(), e.getMessage()));
+                return null;
             }
         }
         return group;
@@ -210,8 +222,8 @@ public class ParquetWriter
     {
 
         switch (columnType) {
-            case INT, INTEGER -> group.append(colName, Integer.parseInt(column.getRawData().toString()));
-            case BIGINT, LONG -> group.append(colName, column.asLong());
+            case TINYINT, SMALLINT, INT -> group.append(colName, Integer.parseInt(column.getRawData().toString()));
+            case BIGINT -> group.append(colName, column.asLong());
             case FLOAT -> group.append(colName, column.asDouble().floatValue());
             case DOUBLE -> group.append(colName, column.asDouble());
             case BOOLEAN -> group.append(colName, column.asBoolean());
@@ -390,7 +402,7 @@ public class ParquetWriter
         Type.Repetition repetition = Type.Repetition.OPTIONAL;
 
         for (Configuration column : columns) {
-            String type = column.getString(Key.TYPE).trim().toUpperCase();
+            String type = column.getString(Key.TYPE).trim().toUpperCase(Locale.ROOT);
             String fieldName = column.getString(Key.NAME);
             Type field = createFieldByType(type, fieldName, repetition, column);
             builder.addField(field);
@@ -428,14 +440,45 @@ public class ParquetWriter
         return getPrimitiveType(type, fieldName, repetition, column);
     }
 
+    /**
+     * Reduce a configured type name to the token the schema switch below is written in.
+     * <p>
+     * The configuration carries the SQL/Hive spellings: aliases ({@code integer}, {@code long})
+     * and parameters ({@code varchar(10)}, {@code char(3)}). None of them matched a case here, so
+     * such a column fell through to the parquet primitive lookup, threw, and was silently
+     * declared as a STRING - a different logical type from the one ORC wrote for the same config.
+     *
+     * @param type the configured type
+     * @return the canonical token, or the upper-cased input when it is not a Hive type at all
+     */
+    private static String canonicalTypeName(String type)
+    {
+        try {
+            return SupportHiveDataType.of(type).name();
+        }
+        catch (IllegalArgumentException e) {
+            // not part of the Hive vocabulary: BYTES and the parquet primitive type names
+            return type.trim().toUpperCase(Locale.ROOT);
+        }
+    }
+
     private static PrimitiveType getPrimitiveType(String type, String fieldName, Type.Repetition repetition, Configuration column)
     {
-        switch (type) {
-            case "INT" -> {
+        switch (canonicalTypeName(type)) {
+            case "TINYINT", "SMALLINT", "INT" -> {
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.INT32, repetition).named(fieldName);
             }
-            case "BIGINT", "LONG" -> {
+            case "BIGINT" -> {
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition).named(fieldName);
+            }
+            case "FLOAT" -> {
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.FLOAT, repetition).named(fieldName);
+            }
+            case "DOUBLE" -> {
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, repetition).named(fieldName);
+            }
+            case "BOOLEAN" -> {
+                return Types.primitive(PrimitiveType.PrimitiveTypeName.BOOLEAN, repetition).named(fieldName);
             }
             case "DECIMAL" -> {
                 int precision = column.getInt(Key.PRECISION, Constant.DEFAULT_DECIMAL_MAX_PRECISION);
@@ -445,12 +488,12 @@ public class ParquetWriter
                         .as(decimalType(scale, precision))
                         .named(fieldName);
             }
-            case "STRING" -> {
+            case "STRING", "VARCHAR", "CHAR" -> {
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
                         .as(LogicalTypeAnnotation.stringType())
                         .named(fieldName);
             }
-            case "BYTES" -> {
+            case "BINARY", "BYTES" -> {
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
                         .named(fieldName);
             }
@@ -463,18 +506,8 @@ public class ParquetWriter
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.INT96, repetition)
                         .named(fieldName);
             }
-            default -> {
-                try {
-                    return Types.primitive(PrimitiveType.PrimitiveTypeName.valueOf(type), repetition)
-                            .named(fieldName);
-                }
-                catch (IllegalArgumentException e) {
-                    logger.warn("Unknown type: {}, using STRING instead", type);
-                    return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
-                            .as(LogicalTypeAnnotation.stringType())
-                            .named(fieldName);
-                }
-            }
+            default -> throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
+                    String.format("Unsupported field type. Field name: [%s], Field type: [%s].", fieldName, type));
         }
     }
 }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
@@ -220,9 +220,25 @@ public class ParquetWriter
                 group.append(colName, decimalToBinary(column.asString(), scale));
             }
             case TIMESTAMP -> group.append(colName, tsToBinary(column.asTimestamp()));
-            case DATE -> group.append(colName, (int) Math.round(column.asLong() * 1.0 / MILLIS_PER_DAY));
-            default -> group.append(colName, formatTimeWithNanos(column));
+            case DATE -> group.append(colName, dateToEpochDay(column));
+            default -> group.append(colName, formatTimeWithNanos(column, columnTimeZone));
         }
+    }
+
+    /**
+     * Converts a DATE column to the number of days since the unix epoch.
+     * <p>
+     * A DATE arrives as an instant at local midnight, so it has to be read as a calendar date.
+     * Dividing the raw millis by {@code MILLIS_PER_DAY} instead counts elapsed days since the
+     * epoch and lands a day early in any zone east of UTC, which also disagreed with
+     * {@link OrcWriter} for the very same job configuration.
+     *
+     * @param column the column holding the date value
+     * @return the epoch day of the date
+     */
+    private static int dateToEpochDay(Column column)
+    {
+        return (int) new java.sql.Date(column.asLong()).toLocalDate().toEpochDay();
     }
 
     /**
@@ -320,8 +336,11 @@ public class ParquetWriter
     private Binary tsToBinary(Timestamp ts)
     {
         long millis = ts.getTime();
-        int julianDays = (int) (millis / MILLIS_PER_DAY) + JULIAN_EPOCH_OFFSET_DAYS;
-        long nanosOfDay = (millis % MILLIS_PER_DAY) * NANOS_PER_MILLISECOND + (ts.getNanos() % (int) NANOS_PER_MILLISECOND);
+        // floorDiv/floorMod rather than plain division: truncation rounds towards zero, so any
+        // pre-1970 value would leave a negative time-of-day inside the 12-byte INT96 buffer
+        int julianDays = (int) Math.floorDiv(millis, MILLIS_PER_DAY) + JULIAN_EPOCH_OFFSET_DAYS;
+        long nanosOfDay = Math.floorMod(millis, MILLIS_PER_DAY) * NANOS_PER_MILLISECOND
+                + ts.getNanos() % NANOS_PER_MILLISECOND;
 
         // Write INT96 timestamp
         byte[] timestampBuffer = new byte[12];

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/SupportHiveDataType.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/SupportHiveDataType.java
@@ -19,6 +19,8 @@
 
 package com.wgzhao.addax.plugin.writer.hdfswriter;
 
+import java.util.Locale;
+
 /** Support Hive Data Type. */
 public enum SupportHiveDataType
 {
@@ -39,5 +41,33 @@ public enum SupportHiveDataType
     BOOLEAN,
     BINARY,
     MAP,
-    ARRAY
+    ARRAY;
+
+    /**
+     * Resolve a configured type name to its constant.
+     * <p>
+     * The configuration is written in the SQL/Hive spelling, which {@link #valueOf} cannot read:
+     * it carries aliases ({@code integer} for {@code int}, {@code long} for {@code bigint}) and
+     * parameters ({@code varchar(10)}, {@code char(3)}, {@code decimal(10,2)}). Calling
+     * {@code valueOf} on the raw string threw {@link IllegalArgumentException} deep inside a task,
+     * after part of the data had already been read.
+     *
+     * @param type the configured type, for example {@code "varchar(10)"}
+     * @return the matching constant
+     * @throws IllegalArgumentException if the type is not supported
+     */
+    public static SupportHiveDataType of(String type)
+    {
+        String name = type.trim().toUpperCase(Locale.ROOT);
+        int parameters = name.indexOf('(');
+        if (parameters >= 0) {
+            name = name.substring(0, parameters).trim();
+        }
+
+        return switch (name) {
+            case "INTEGER" -> INT;
+            case "LONG" -> BIGINT;
+            default -> valueOf(name);
+        };
+    }
 }

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
@@ -107,7 +107,7 @@ public class TextWriter
     }
 
     /** Transportonerecord. */
-    public static MutablePair<Text, Boolean> transportOneRecord(
+    public MutablePair<Text, Boolean> transportOneRecord(
             Record record, char fieldDelimiter, List<Configuration> columnsConfiguration, TaskPluginCollector taskPluginCollector)
     {
         MutablePair<List<Object>, Boolean> transportResultList = transportOneRecord(record, columnsConfiguration, taskPluginCollector);
@@ -120,7 +120,7 @@ public class TextWriter
     }
 
     /** Transportonerecord. */
-    public static MutablePair<List<Object>, Boolean> transportOneRecord(
+    public MutablePair<List<Object>, Boolean> transportOneRecord(
             Record record, List<Configuration> columnsConfiguration,
             TaskPluginCollector taskPluginCollector)
     {
@@ -145,7 +145,7 @@ public class TextWriter
                             case BIGINT -> recordList.add(column.asLong());
                             case FLOAT -> recordList.add(Float.valueOf(rowData));
                             case DOUBLE -> recordList.add(column.asDouble());
-                            case STRING, VARCHAR, CHAR -> recordList.add(formatTimeWithNanos(column));
+                            case STRING, VARCHAR, CHAR -> recordList.add(formatTimeWithNanos(column, columnTimeZone));
                             case DECIMAL -> recordList.add(HiveDecimal.create(column.asBigDecimal()));
                             case BOOLEAN -> recordList.add(column.asBoolean());
                             case DATE -> recordList.add(org.apache.hadoop.hive.common.type.Date.valueOf(column.asString()));

--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/TextWriter.java
@@ -19,6 +19,7 @@
 
 package com.wgzhao.addax.plugin.writer.hdfswriter;
 
+import com.wgzhao.addax.core.base.Constant;
 import com.wgzhao.addax.core.base.Key;
 import com.wgzhao.addax.core.element.Column;
 import com.wgzhao.addax.core.element.Record;
@@ -42,11 +43,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.IO_ERROR;
 import static com.wgzhao.addax.core.spi.ErrorCode.NOT_SUPPORT_TYPE;
@@ -58,6 +62,17 @@ public class TextWriter
 {
     private final static Logger logger = LoggerFactory.getLogger(TextWriter.class.getName());
 
+    /**
+     * The per-task options that shape every output line.
+     *
+     * @param fieldDelimiter the delimiter placed between two fields
+     * @param encoding the charset the line is written in
+     * @param nullFormat the text written for a null field, or null to keep it empty
+     */
+    private record TextOptions(char fieldDelimiter, Charset encoding, String nullFormat)
+    {
+    }
+
     /** Textwriter. */
     public TextWriter(Configuration conf)
     {
@@ -68,9 +83,12 @@ public class TextWriter
     @Override
     public void write(RecordReceiver lineReceiver, Configuration config, String fileName, TaskPluginCollector taskPluginCollector)
     {
-        char fieldDelimiter = config.getChar(Key.FIELD_DELIMITER);
         List<Configuration> columns = config.getListConfiguration(Key.COLUMN);
-        String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase().trim();
+        String compress = config.getString(Key.COMPRESS, "NONE").toUpperCase(Locale.ROOT).trim();
+        TextOptions options = new TextOptions(
+                config.getChar(Key.FIELD_DELIMITER),
+                Charset.forName(config.getString(Key.ENCODING, Constant.DEFAULT_ENCODING)),
+                config.getString(Key.NULL_FORMAT, null));
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmm");
         String attempt = "attempt_" + dateFormat.format(new Date()) + "_0001_m_000000_0";
@@ -91,7 +109,7 @@ public class TextWriter
                     .getRecordWriter(fileSystem, conf, outputPath.toString(), Reporter.NULL);
             Record record;
             while ((record = lineReceiver.getFromReader()) != null) {
-                MutablePair<Text, Boolean> transportResult = transportOneRecord(record, fieldDelimiter, columns, taskPluginCollector);
+                MutablePair<Text, Boolean> transportResult = transportOneRecord(record, columns, taskPluginCollector, options);
                 if (Boolean.FALSE.equals(transportResult.getRight())) {
                     writer.write(NullWritable.get(), transportResult.getLeft());
                 }
@@ -100,29 +118,34 @@ public class TextWriter
         }
         catch (IOException e) {
             logger.error("IO exception occurred while writing text file [{}]", fileName);
-            Path path = new Path(fileName);
-            deleteDir(path.getParent());
+            // no per-task cleanup here: the parent is the staging directory shared by every split
+            // task, and Job.destroy() removes the whole staging directory on failure anyway
             throw AddaxException.asAddaxException(IO_ERROR, e);
         }
     }
 
     /** Transportonerecord. */
     public MutablePair<Text, Boolean> transportOneRecord(
-            Record record, char fieldDelimiter, List<Configuration> columnsConfiguration, TaskPluginCollector taskPluginCollector)
+            Record record, List<Configuration> columnsConfiguration,
+            TaskPluginCollector taskPluginCollector, TextOptions options)
     {
-        MutablePair<List<Object>, Boolean> transportResultList = transportOneRecord(record, columnsConfiguration, taskPluginCollector);
+        MutablePair<List<Object>, Boolean> transportResultList =
+                toFieldList(record, columnsConfiguration, taskPluginCollector, options);
         MutablePair<Text, Boolean> transportResult = new MutablePair<>();
         transportResult.setRight(false);
-        Text recordResult = new Text(StringUtils.join(transportResultList.getLeft(), fieldDelimiter));
+        // a Text is a plain byte container: encoding the line here is what makes the configured
+        // encoding reach the file, because LineRecordWriter writes the bytes through untouched
+        Text recordResult = new Text(StringUtils.join(transportResultList.getLeft(), options.fieldDelimiter())
+                .getBytes(options.encoding()));
         transportResult.setRight(transportResultList.getRight());
         transportResult.setLeft(recordResult);
         return transportResult;
     }
 
     /** Transportonerecord. */
-    public MutablePair<List<Object>, Boolean> transportOneRecord(
+    public MutablePair<List<Object>, Boolean> toFieldList(
             Record record, List<Configuration> columnsConfiguration,
-            TaskPluginCollector taskPluginCollector)
+            TaskPluginCollector taskPluginCollector, TextOptions options)
     {
 
         MutablePair<List<Object>, Boolean> transportResult = new MutablePair<>();
@@ -135,9 +158,11 @@ public class TextWriter
                 column = record.getColumn(i);
                 if (null != column.getRawData()) {
                     String rowData = column.getRawData().toString();
-                    SupportHiveDataType columnType = SupportHiveDataType.valueOf(
-                            columnsConfiguration.get(i).getString(Key.TYPE).toUpperCase());
                     try {
+                        // resolve inside the try: an unsupported type is a per-record conversion
+                        // failure that belongs in the dirty records, not a task-killing throw
+                        SupportHiveDataType columnType = SupportHiveDataType.of(
+                                columnsConfiguration.get(i).getString(Key.TYPE));
                         switch (columnType) {
                             case TINYINT -> recordList.add(Byte.valueOf(rowData));
                             case SMALLINT -> recordList.add(Short.valueOf(rowData));
@@ -150,7 +175,9 @@ public class TextWriter
                             case BOOLEAN -> recordList.add(column.asBoolean());
                             case DATE -> recordList.add(org.apache.hadoop.hive.common.type.Date.valueOf(column.asString()));
                             case TIMESTAMP -> recordList.add(Timestamp.valueOf(column.asString()));
-                            case BINARY -> recordList.add(column.asBytes());
+                            // base64 rather than the raw array: joining a byte[] would render its
+                            // identity hash and lose the content entirely
+                            case BINARY -> recordList.add(Base64.getEncoder().encodeToString(column.asBytes()));
                             default -> throw AddaxException.asAddaxException(
                                     NOT_SUPPORT_TYPE,
                                     String.format(
@@ -163,7 +190,7 @@ public class TextWriter
                     catch (Exception e) {
                         logger.warn("Warn: convert field[{}] from [{}] to [{}] error.",
                                 columnsConfiguration.get(i).getString(Key.NAME),
-                                column.getRawData(), columnType);
+                                column.getRawData(), columnsConfiguration.get(i).getString(Key.TYPE));
                         String message = String.format(
                                 "Type conversion error：target field type: [%s], field value: [%s].",
                                 columnsConfiguration.get(i).getString(Key.TYPE), column.getRawData());
@@ -173,8 +200,9 @@ public class TextWriter
                     }
                 }
                 else {
-                    // warn: it's all ok if nullFormat is null
-                    recordList.add(null);
+                    // nullFormat stays null when it is not configured, which renders as an empty
+                    // field exactly as before
+                    recordList.add(options.nullFormat());
                 }
             }
         }

--- a/plugin/writer/hdfswriter/src/main/resources/plugin_job_template.json
+++ b/plugin/writer/hdfswriter/src/main/resources/plugin_job_template.json
@@ -30,8 +30,8 @@
         "type": "string"
       }
     ],
-    "bloom.filter.columns": ["col1", "col3"],
-    "bloom.filter.fpp": 0.05,
+    "bloomColumns": ["col1", "col3"],
+    "bloomFpp": 0.05,
     "writeMode": "overwrite",
     "fieldDelimiter": "\u0001",
     "compress": "SNAPPY",


### PR DESCRIPTION
## Summary

Second pass of the `hdfswriter` audit. Fixes the failure-path and configuration defects that could
silently lose data or abort a job after the data had already been read. Stacked on top of #1533 —
please merge that one first, or retarget this PR to `master` once it lands.

As in the first PR, every defect was reproduced by driving the real writer classes against a
synthetic `RecordReceiver` with `defaultFS=file:///`, then reading the produced file back.

## Related Issue(s)

Relates to #1533 (this branch is based on it).

## What type of change is this?

- [x] Bugfix

## Changes

**Failure paths**

- `HdfsHelper.moveFilesToDest`: check the boolean returned by `rename` (it reports several failures
  that way rather than by throwing) and refuse to move onto a name that already exists, because on
  the local and other `FileSystem` implementations `rename` silently replaces it. `Job.post()`
  deletes the staging directory right afterwards, so either case used to destroy the file while
  the job still reported success.
- `HdfsHelper.deleteFilesFromDir`: check `moveToTrash` and `delete`. A refused trash move left the
  previous run's data in place next to the newly written files.
- `OrcWriter`/`TextWriter`: stop deleting the *parent* directory in the `IOException` handler. That
  directory is the staging directory shared by every split task, so one task's failure wiped out
  its siblings' completed output.
- `HdfsWriter.Job.destroy`: delete the staging directory there instead. `destroy()` runs in the
  `finally` of `JobContainer.start()`, so it also covers the failure path where `post()` never runs.
- `HdfsWriter.Job.split`: generate one middle name per task instead of two, and compare bare file
  names. The collision guard compared an independently random name against fully qualified paths,
  so it could never fire.
- `HdfsWriter.Job.prepare`: ignore hidden entries when checking `nonConflict` — they are this
  plugin's own staging directories, and the readers skip them too.

**Configuration contract**

- `writeMode=truncate` is now implemented (it is accepted by the shared validator but nothing acted
  on it, so the job silently behaved like `append`), and `overwrite` clears sub-directories again.
- `StorageWriterUtil.validateWriteMode` matches case-insensitively and stores the canonical
  spelling, restoring what the pre-refactor code did.
- `SupportHiveDataType.of` is the single entry point for parsing a configured type name: it accepts
  the SQL aliases (`integer`, `long`) and the parameters (`varchar(10)`, `char(3)`,
  `decimal(10,2)`) that `valueOf` rejected. All three writers use it.
- `OrcWriter` translates `integer`/`long` to the spellings ORC's parser knows, and rejects a
  non-string map key at schema build instead of throwing `ClassCastException` mid-batch.
- `ParquetWriter` maps `tinyint`/`smallint` to INT32 and `long` to INT64 (they were silently
  declared as STRING), and sends a value the declared type cannot hold to the dirty collector
  instead of appending it as a string into a typed field.
- `TextWriter` resolves the type inside the `try`, so an unsupported type becomes a dirty record
  rather than an uncaught `IllegalArgumentException`, and Base64-encodes BINARY instead of writing
  the array's identity hash.
- Text codecs come from one map shared by validation and lookup, and ZSTD is gone from it: hadoop's
  `ZStandardCodec` needs native libhadoop rather than the zstd-jni jar, so it only ever failed
  inside the task.
- The ORC bloom filter keys in `plugin_job_template.json` now match the keys the code reads, and
  `addax-gen` strips the same spelling.
- `encoding` is applied by encoding the line at the `Text` boundary (a `Text` is a byte container,
  so `LineRecordWriter` writes the bytes through untouched), and `nullFormat` is honoured.

## Motivation and Context

The first pass fixed what the writer *stored*. This pass addresses what it *loses* and what it
*refuses to do*:

- A single task's transient IOException recursively deleted the staging directory shared by all
  tasks, including files its siblings had already finished writing.
- A failed `rename` or `moveToTrash` was logged as success and the file was then deleted with the
  staging directory — the job exited 0 with the data gone.
- `writeMode=truncate` is documented and accepted but did nothing, so every re-run appended to the
  previous run's files and Hive returned the rows twice.
- `integer`, `long`, `varchar(10)` and `char(3)` — spellings the plugin's own enum declares and the
  reader templates use — aborted the task mid-write, in one case after the whole job had read its
  input.
- `encoding`, `nullFormat` and the documented bloom filter keys validated cleanly and had no effect.

## How has this been tested?

No automated tests were added; the project does not carry unit tests, and these were verified
manually against `defaultFS=file:///`.

1. Build: `mvn clean package -T1C -DskipTests` — BUILD SUCCESS.
2. A check harness drives the three writers plus `HdfsHelper` against a local filesystem and reads
   the output back. 25 assertions, all passing, including:

   | Check | Before | After |
   | --- | --- | --- |
   | `HdfsHelper.deleteFilesFromDir` on a partitioned directory | only top-level files removed, `dt=.../part-1.txt` survived | nested file removed, `.<staging>` preserved |
   | `moveFilesToDest` onto an existing name | silently replaced the existing file | throws, existing file intact |
   | TEXT column typed `long` | every row a dirty record, empty file, job "succeeds" | written |
   | TEXT `varchar(10)` | uncaught `IllegalArgumentException`, task died | written |
   | TEXT `encoding=GBK` + `nullFormat` | UTF-8 bytes, empty field | GBK bytes verified by re-decoding, `\N` |
   | TEXT `binary` column | `[B@1a86f2f1` | base64 |
   | ORC `integer` / `long` / `varchar(10)` | `Can't parse category at 'integer^'` | `struct<i:int,l:bigint,m:map<string,int>,s:varchar(10)>` |
   | ORC `map<int,string>` | `ClassCastException` mid-batch | rejected before any data is read |
   | parquet `tinyint` / `smallint` / `long` | silently declared STRING | INT32 / INT32 / INT64 |
   | parquet non-numeric value for an `int` column | `ClassCastException` inside the writer | dirty record, row skipped, good rows written |
3. The first PR's checks were re-run against this branch to confirm no regression: pre-1970 INT96,
   the DATE epoch day and the TIME wall clock are unchanged.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable). — the project carries no unit tests; see the matrix above.
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/). — the plugin job template was corrected.
- [ ] I updated CHANGELOG.md when appropriate. — no CHANGELOG in the repo.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

`hdfswriter` no longer loses staged data when a task or a move fails, cleans its staging directory
on every exit path, implements `writeMode=truncate`, and accepts the column type spellings
(`integer`, `long`, `varchar(n)`, `char(n)`) and codecs it documented. `encoding`, `nullFormat` and
the ORC bloom filter keys now do what they say.

## Breaking changes / Migration

- `compress=ZSTD` for `fileType=text` is now rejected at validation, because hadoop's
  `ZStandardCodec` cannot be instantiated without native libhadoop and previously failed inside the
  task after the data had been read. Use GZIP or SNAPPY.
- `moveFilesToDest` now refuses to overwrite an existing destination name instead of replacing it.
  This only triggers where the destination already holds a file with the same generated name, which
  the `split()` collision guard is meant to prevent.
- An unsupported column type now fails at schema build rather than producing a STRING column in
  parquet. A job relying on a misspelled type was already writing the wrong logical type.

## Additional context

`createPath`, `skipTrash`, `batchSize`, `hdfsSitePath` and the column-level `precision`/`scale` are
still not mentioned in `plugin_job_template.json`. That is a documentation gap rather than a
defect, so it is not part of this PR.

The per-cell cost of the writers (re-resolving the column name, type and scale from the
`Configuration` for every field of every record) was also reported by the audit and is not
addressed here; it is a performance change rather than a correctness one and deserves its own PR.
