### PR TITLE
fix(ci): lint the actual PR commits and ignore GitHub's squash suffix

### DIFF
--- a/.github/scripts/lint-commit-msg.sh
+++ b/.github/scripts/lint-commit-msg.sh
@@ -29,8 +29,11 @@ if [[ -z "$header" ]]; then
   exit 1
 fi
 
-if (( ${#header} > 100 )); then
-  echo "commit header exceeds 100 chars (${#header}): $header" >&2
+# GitHub appends " (#123)" when squash-merging, so measure the authored subject only.
+subject="$(sed -E 's/ \(#[0-9]+\)$//' <<<"$header")"
+
+if (( ${#subject} > 100 )); then
+  echo "commit header exceeds 100 chars (${#subject}): $subject" >&2
   exit 1
 fi
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,8 +22,12 @@ jobs:
           fetch-depth: 0
       - name: Lint commit messages in PR
         run: |
+          # Do not add a `git fetch --depth=1` of the base branch here: it marks
+          # origin/<base> shallow, and once master moves past the PR branch the
+          # base ref stops being an ancestor of HEAD, so the range below degenerates
+          # to nearly the whole repository history and the job fails on commits that
+          # are already on master. actions/checkout (fetch-depth: 0) already has it.
           base="origin/${{ github.base_ref }}"
-          git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
           commits=$(git rev-list --no-merges "$base"..HEAD)
           if [[ -z "$commits" ]]; then
             echo "no non-merge commits to lint"


### PR DESCRIPTION
## Summary

Fixes the `commit-message-lint` job, which was failing for reasons unrelated to the PR under test. Two independent defects:

1. **Wrong commit range.** The job fetched `origin/<base>` with `--depth=1`, which marks that ref **shallow**. As soon as master had moved past the PR branch, the base ref was no longer an ancestor of `HEAD`, so `git rev-list --no-merges origin/master..HEAD` degenerated from "the PR's own commits" to nearly the entire repository history. The loop then aborted (`bash -e`) at the first commit violating the rules — a commit that was **already merged into master**.
2. **Wrong length measurement.** The 100-char header limit was applied to the raw subject, including the ` (#123)` suffix GitHub appends on squash-merge, so a compliant PR title could fail with no way to fix it locally.

## Related Issue(s)

None. Observed on the lint run for #1536.

## What type of change is this?
- [x] Build / CI

## Changes

- `.github/workflows/verify.yml`: drop the redundant `git fetch --depth=1` of the base branch — `actions/checkout` with `fetch-depth: 0` already fetches every branch (`+refs/heads/*:refs/remotes/origin/*`). A comment documents why `--depth=1` must not be reintroduced. The commit range expression itself is unchanged.
- `.github/scripts/lint-commit-msg.sh`: strip a trailing ` (#123)` before measuring header length. The 100-char rule is otherwise untouched, and the local `.githooks/commit-msg` path shares this script, so both stay consistent.

## Motivation and Context

The check was red whenever master had advanced past a PR's base, and green otherwise — it carried no information about the PR's own commits. Four recent PRs (#1532, #1534, #1535, #1536) were merged with it failing, which trains contributors to ignore the gate.

Evidence from the failing run of #1536 (`linting commit:` lines):

```
linting commit: 93ef298069f1...   <- PR branch
...
linting commit: c02e56e81e83...   <- already on master
linting commit: 88fecb068213...   <- already on master
...
commit header exceeds 100 chars (104): refactor(lib-storage): decode local files with one open and single-source wildcard normalization (#1523)
##[error]Process completed with exit code 1.
```

`git rev-list` returned 15 commits; 8 of them are ancestors of master. The reported header is 104 chars — 95 without the ` (#1523)` suffix.

## How has this been tested?

Manual, on a scratch clone of this repository (no Java code is touched, so no Maven build is meaningful here):

1. **Range, before/after** — branch checked out at an older master commit (`c02e56e81`) plus 3 synthetic commits, with `origin/master` at the current tip:

   | | commits linted |
   | --- | --- |
   | old: `git fetch --depth=1` + `origin/master..HEAD` | 1969 |
   | new: `origin/master..HEAD` (full history) | 3 (only the PR's own) |

   Also verified the empty case: `HEAD == origin/master` → range empty → `no non-merge commits to lint`, exit 0.

2. **Length rule** — run against real commit messages:

   | input | before | after |
   | --- | --- | --- |
   | `581a456b3` (#1523, 104 chars) | exit 1 | exit 0 (95 chars) |
   | authored subject of 121 chars | exit 1 | exit 1 (still rejected) |
   | all 15 commits from the failing run | fails at the 15th | all pass |

   100-char headers without a suffix are still rejected, and the format/body checks are untouched.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). *(N/A — CI shell only; verified as described above)*
- [ ] I ran a local build and fixed any compilation issues. *(no Java code changed, so no build was run)*
- [x] I updated or added documentation if needed (README, docs/ or docs/en/). *(the workflow comment documents the pitfall)*
- [ ] I updated CHANGELOG.md when appropriate. *(no CHANGELOG.md in this repository)*
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project. *(not required by the project)*

## Release notes

No user-facing change: this only repairs the `commit-message-lint` CI job.

## Breaking changes / Migration

None.

## Additional context

`git merge-base` was considered as the range anchor instead of `origin/<base>`. It was rejected: if the base ref is ever shallowed again, `merge-base` silently returns a wrong commit (in testing it returned `HEAD`, producing an empty range and a **false green**), whereas the plain range expression fails loudly by over-including.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
