### PR TITLE
fix(plugin-hdfswriter): write LZ4 parquet files as LZ4_RAW

### DIFF
--- a/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
+++ b/plugin/writer/hdfswriter/src/main/java/com/wgzhao/addax/plugin/writer/hdfswriter/ParquetWriter.java
@@ -132,7 +132,7 @@ public class ParquetWriter
     {
         List<Configuration> columns = config.getListConfiguration(Key.COLUMN);
         String compress = config.getString(Key.COMPRESS, "UNCOMPRESSED").toUpperCase().trim();
-        CompressionCodecName codecName = CompressionCodecName.fromConf(compress.equals("NONE") ? "UNCOMPRESSED" : compress);
+        CompressionCodecName codecName = resolveCodec(compress);
 
         // Construct parquet schema, which also validates the configured types
         MessageType schema = generateParquetSchema(columns);
@@ -149,6 +149,19 @@ public class ParquetWriter
         catch (IOException e) {
             throw new RuntimeException("Failed to write Parquet file: " + fileName, e);
         }
+    }
+
+    /**
+     * Resolve the configured compression name to the codec the file is written with.
+     * <p>
+     * LZ4 is upgraded to LZ4_RAW on purpose: parquet's plain LZ4 codec writes the Hadoop framing
+     * that parquet-format deprecated (codec 5), which only readers carrying lz4-java can decode.
+     * LZ4_RAW (codec 7) is what every modern engine writes and reads.
+     */
+    private static CompressionCodecName resolveCodec(String compress)
+    {
+        CompressionCodecName codecName = CompressionCodecName.fromConf("NONE".equals(compress) ? "UNCOMPRESSED" : compress);
+        return codecName == CompressionCodecName.LZ4 ? CompressionCodecName.LZ4_RAW : codecName;
     }
 
     private void setupHadoopConfiguration(MessageType schema)

--- a/plugin/writer/s3writer/src/main/java/com/wgzhao/addax/plugin/writer/s3writer/writer/ParquetWriter.java
+++ b/plugin/writer/s3writer/src/main/java/com/wgzhao/addax/plugin/writer/s3writer/writer/ParquetWriter.java
@@ -238,10 +238,7 @@ public class ParquetWriter
     {
         List<Configuration> columns = config.getListConfiguration(Key.COLUMN);
         String compress = config.getString(Key.COMPRESS, "UNCOMPRESSED").toUpperCase().trim();
-        if ("NONE".equals(compress)) {
-            compress = "UNCOMPRESSED";
-        }
-        CompressionCodecName codecName = CompressionCodecName.fromConf(compress);
+        CompressionCodecName codecName = resolveCodec(compress);
         // construct parquet schema
         MessageType s = generateParquetSchema(columns);
         Path path = new Path(fileName);
@@ -276,6 +273,19 @@ public class ParquetWriter
         catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Resolve the configured compression name to the codec the file is written with.
+     * <p>
+     * LZ4 is upgraded to LZ4_RAW on purpose: parquet's plain LZ4 codec writes the Hadoop framing
+     * that parquet-format deprecated (codec 5), which only readers carrying lz4-java can decode.
+     * LZ4_RAW (codec 7) is what every modern engine writes and reads.
+     */
+    private static CompressionCodecName resolveCodec(String compress)
+    {
+        CompressionCodecName codecName = CompressionCodecName.fromConf("NONE".equals(compress) ? "UNCOMPRESSED" : compress);
+        return codecName == CompressionCodecName.LZ4 ? CompressionCodecName.LZ4_RAW : codecName;
     }
 
     /** Buildrecord. */


### PR DESCRIPTION
## Summary

Configuring `compress: LZ4` on a parquet job made the writers emit the Hadoop-framed LZ4 codec, which `parquet.thrift` ships marked as deprecated (`LZ4 = 5; // DEPRECATED (Added in 2.4)`). Files with that codec can only be decompressed by readers that carry `lz4-java`, which is how hdfswriter came to need the dependency (#1531) and then hdfsreader (#1533) just to read back its own output.

This PR removes the cause instead of paying for it on the read side: the parquet writers of hdfswriter and s3writer now resolve `LZ4` to `LZ4_RAW` (codec 7). Every other codec name is untouched.

## Related Issue(s)

No tracking issue; this came out of verifying the round trip of #1531 / #1533.

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [x] Breaking change (changes API or runtime behavior)

## Changes

- `plugin/writer/hdfswriter` — `ParquetWriter` resolves the configured compression through a new `resolveCodec()` helper: `LZ4` becomes `LZ4_RAW`, any other name goes through `CompressionCodecName.fromConf` exactly as before.
- `plugin/writer/s3writer` — the same helper in its parquet writer.
- `lz4-java` stays declared in hdfswriter, s3writer and hdfsreader on purpose: files written by 6.0.13 and earlier still carry codec 5 and still need it on the classpath to be read.

## Motivation and Context

The failure moved around as each end was fixed:

1. #1531 added `org.lz4:lz4-java` to hdfswriter and s3writer, because hadoop-common declares it as `provided` and writing LZ4 parquet threw `NoClassDefFoundError: net/jpountz/lz4/LZ4Factory`.
2. #1533 added the same dependency to hdfsreader, because reading that file back failed with the very same error from `org.apache.hadoop.io.compress.lz4.Lz4Decompressor`.

Both were symptoms of choosing the deprecated codec. Modern engines (Spark 3 with `lz4`, for one) write `LZ4_RAW`, which parquet decompresses through its own aircompressor-backed `Lz4RawCodec`, so no extra runtime dependency is involved at either end. Sibling codec names that legitimately mean the Hadoop framing — TEXT/CSV via `HdfsHelper.COMPRESS_CODECS`, ORC via `CompressionKind` — are deliberately left alone.

## How has this been tested?

No unit tests: this project verifies plugins manually, so the change was checked with a round-trip harness that drives the real plugin classes against `file:///` (no HDFS needed), stubbing `RecordReceiver`/`RecordSender` and calling `ParquetWriter.write()` and `HdfsReader.Task.startRead()`.

1. Build: `mvn -o clean package -pl :hdfswriter,:s3writer -DskipTests`
2. Write 5 records per codec with hdfswriter, read each file back with the hdfsreader classpath deliberately **missing** `lz4-java`, so a lazily-required dependency fails the test instead of hiding in it.

```
compress=UNCOMPRESSED  codec:UNCOMPRESSED  records=5
compress=NONE          codec:UNCOMPRESSED  records=5
compress=SNAPPY        codec:SNAPPY        records=5
compress=GZIP          codec:GZIP          records=5
compress=LZ4           codec:LZ4_RAW       records=5   <- was codec:LZ4 before this change
compress=LZ4_RAW       codec:LZ4_RAW       records=5
```

3. Backward compatibility, verified separately: an LZ4 file written before this change (codec 5) is still read correctly by the shipped hdfsreader, and fails with the reported `NoClassDefFoundError` only when lz4-java is removed from its classpath by hand. Deleting the dependency from the pom is therefore not an option, and this PR does not do it.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Release notes

PARQUET: `compress: LZ4` writes LZ4_RAW (codec 7) pages, the variant Spark, Trino and parquet-mr >= 1.12 use. Files written by earlier releases keep working.

## Breaking changes / Migration

The configuration key and its accepted values do not change, but the codec of the files written for `LZ4` does. A consumer built on parquet-mr older than 1.12 cannot decode codec 7 at all — Hive 3.1.x ships 1.10.1, for example. Jobs feeding such consumers should either stay on an older addax release or pick `SNAPPY`/`GZIP`; anything modern reads LZ4_RAW and does not need the change.

## Additional context

`LZ4_RAW` was already accepted as a value before this PR (`CompressionCodecName.values()` was the validation list), so this only makes the plain `LZ4` name mean the codec everyone else means by it. The codec names in the user-facing docs live in the separate addax-docs repository and were not touched here.
