### PR TITLE
chore(deps): ignore flight-sql-jdbc-core 19.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     ignore:
       - dependency-name: "ojbdc8"
         versions: ["21.x"]
+      # 19.x needs protobuf-java 4.x, but the root pom pins protobuf-java to 3.25.5,
+      # so the bump ships a classpath that fails when the Flight classes initialise (#1492)
+      - dependency-name: "org.apache.arrow:flight-sql-jdbc-core"
+        versions: ["19.x"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

`@dependabot ignore this major version` on #1492 closed the pull request but left no ignore condition behind, so the Arrow Flight SQL bump would be proposed again on the next scheduled run. This adds the rule explicitly.

## Related Issue(s)

Relates to #1492 (closed).

## What type of change is this?

- [ ] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [x] Build / CI
- [x] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- `.github/dependabot.yml`: ignore `org.apache.arrow:flight-sql-jdbc-core` versions `19.x`, with a comment pointing at the reason.

## Motivation and Context

#1492 cannot be taken as-is. Arrow 19.0.0 requires protobuf-java 4.33.4, but the root pom pins `protobuf.version` to 3.25.5 (`pom.xml:106`, dependencyManagement at `pom.xml:385`), and dependencyManagement wins over transitive versions, so the plugin classpath keeps protobuf-java 3.25.5. Arrow 19's generated Flight messages call protobuf 4 APIs from their static initializer:

```
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/protobuf/RuntimeVersion$RuntimeDomain
	at org.apache.arrow.flight.impl.Flight$FlightDescriptor.<clinit>(Flight.java:5088)
```

CI cannot catch this, because `verify` compiles and packages without ever loading the Flight classes; the failure only appears when a job connects. Upgrading properly means migrating the shared protobuf pin to 4.x (a breaking major for every module that takes protobuf-java from the root management), accepting Arrow 19's companion jumps (netty 4.1 -> 4.2, grpc 1.70 -> 1.79, avatica, bcpkix) and testing against a real Doris FE -- separate work, tracked by the closed pull request.

## How has this been tested?

No code path changes; YAML syntax checked by eye against the surrounding entries. The underlying failure was reproduced as described in #1492 with `java -cp flight-core-<v>.jar:arrow-format-18.2.0.jar:protobuf-java-<v>.jar` and a probe that loads and serializes `org.apache.arrow.flight.impl.Flight$FlightDescriptor`.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Additional context

While editing this file I noticed the pre-existing Oracle entry reads `ojbdc8` (missing the `j`, the artifact is `com.oracle.database.jdbc:ojdbc8`), so that rule presumably never matched anything. It is left untouched here; say the word and I will fix it in a follow-up.
