### PR TITLE
chore(deps): hold the Arrow and Paimon bumps dependabot keeps proposing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,16 @@ updates:
     ignore:
       - dependency-name: "ojbdc8"
         versions: ["21.x"]
-      # 19.x needs protobuf-java 4.x, but the root pom pins protobuf-java to 3.25.5,
-      # so the bump ships a classpath that fails when the Flight classes initialise (#1492)
+      # every release from 18.3.0 on ships protobuf 4.x gencode, but the root pom pins
+      # protobuf-java to 3.25.5, so the resolved classpath fails when the Flight classes
+      # initialise (see #1492 and #1541); 18.2.x stays eligible
       - dependency-name: "org.apache.arrow:flight-sql-jdbc-core"
-        versions: ["19.x"]
+        versions: [">=18.3.0"]
+      # 2.0.0 is a table-format and engine major three release lines ahead of the 1.2.0
+      # this plugin pins, so it needs a deliberate migration and a test against the target
+      # Paimon deployment, not a dependency bump (#1540)
+      - dependency-name: "org.apache.paimon:*"
+        versions: ["2.x"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Two of today's dependabot pull requests cannot be merged, and the ignore rule that should have covered one of them was too narrow. This widens it and adds the second rule.

## Related Issue(s)

Relates to #1541, #1540, #1492 (all closed).

## What type of change is this?

- [ ] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [x] Build / CI
- [x] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- `org.apache.arrow:flight-sql-jdbc-core`: ignore `>=18.3.0` instead of `19.x`.
- `org.apache.paimon:*`: ignore `2.x`.

## Motivation and Context

**Arrow (#1541).** #1539 added an ignore for `19.x` on the assumption that 18.x was safe. It is not: the 18.3.0 BOM moves protobuf to 4.30.2 (18.2.0 was on 3.25.5), and the root pom pins `protobuf-java` to 3.25.5 (`pom.xml:106`, dependencyManagement at `pom.xml:385`), which overrides Arrow's transitive version. Arrow's generated Flight messages are protobuf 4 gencode:

```
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/protobuf/RuntimeVersion$RuntimeDomain
	at org.apache.arrow.flight.impl.Flight$FlightDescriptor.<clinit>(Flight.java:5087)
```

Measured with `java -cp flight-core-18.3.0.jar:arrow-format-18.2.0.jar:protobuf-java-3.25.5.jar` and a probe that loads and serializes `org.apache.arrow.flight.impl.Flight$FlightDescriptor`; the 18.2.0 counterpart prints `SERIALIZE OK` on the same classpath. So the boundary is 18.2.x, not 19.0.0, and the rule now says so. 18.2.x patches remain eligible.

**Paimon (#1540).** 2.0.0 is three release lines ahead of the pinned 1.2.0 (1.3.0/1.3.1/1.3.2, 1.4.1/1.4.2, 2.0.0 per Maven Central) and is a table-format and engine major. `paimonwriter` resolves tables through `CatalogFactory`/`getTable` and writes with `BatchTableWrite`, so what changes is not only the API surface but what lands in the table and which engines can still read it -- nothing a compile-only CI run can validate. That needs a deliberate migration and a test against the Paimon deployment in use.

## How has this been tested?

Configuration only; the underlying Arrow failure was reproduced as described above and in #1492. The two dependabot pull requests are closed with these findings posted on them.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Additional context

Both entries carry a comment explaining the condition for removing them: the Arrow rule goes away when `protobuf-java` moves to 4.x, the Paimon rule when the writer is migrated.
