### PR TITLE
perf(plugin-doriswriter): reuse pooled connections and fix the flush lifecycle

### DIFF
--- a/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisKey.java
+++ b/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisKey.java
@@ -46,6 +46,10 @@ public class DorisKey
 
     private static final int MAX_RETRIES = 3;
     private static final long DEFAULT_FLUSH_INTERVAL = 3_000;
+    private static final int DEFAULT_CONNECT_TIMEOUT = 5_000;
+    private static final int DEFAULT_SOCKET_TIMEOUT = 600_000;
+    private static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT = 5_000;
+    private static final long DEFAULT_HOST_COOLDOWN_MS = 30_000;
 
     private static final String LOAD_PROPS_FORMAT = "format";
 
@@ -61,6 +65,10 @@ public class DorisKey
     private static final String LOAD_PROPS = "loadProps";
     private static final String COLUMN_SEPARATOR = "column_separator";
     private static final String LINE_SEPARATOR = "line_delimiter";
+    private static final String CONNECT_TIMEOUT = "connectTimeout";
+    private static final String SOCKET_TIMEOUT = "socketTimeout";
+    private static final String CONNECTION_REQUEST_TIMEOUT = "connectionRequestTimeout";
+    private static final String HOST_COOLDOWN_MS = "hostCooldownMs";
     private static final String DEFAULT_LABEL_PREFIX = "addax_doris_writer_";
 
     private final Configuration loadProps;
@@ -194,10 +202,39 @@ public class DorisKey
         return MAX_RETRIES;
     }
 
-    /** Returns the batchsize. */
+    /**
+     * Returns the max rows of a single stream load batch.
+     *
+     * <p>This plugin, like every other writer in the project, reads `batchSize` as a row
+     * count.  It is *not* a byte limit here, unlike the DataX doriswriter.</p>
+     */
     public long getBatchSize()
     {
         return options.getLong(BATCH_SIZE, DEFAULT_BATCH_SIZE);
+    }
+
+    /** Returns the connecttimeout. */
+    public int getConnectTimeout()
+    {
+        return options.getInt(CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
+    }
+
+    /** Returns the sockettimeout. */
+    public int getSocketTimeout()
+    {
+        return options.getInt(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+    }
+
+    /** Returns the connectionrequesttimeout. */
+    public int getConnectionRequestTimeout()
+    {
+        return options.getInt(CONNECTION_REQUEST_TIMEOUT, DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+    }
+
+    /** Returns how long a failed load host is skipped, in milliseconds. */
+    public long getHostCooldownMs()
+    {
+        return options.getLong(HOST_COOLDOWN_MS, DEFAULT_HOST_COOLDOWN_MS);
     }
 
     /** Returns the flushinterval. */

--- a/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisStreamLoadObserver.java
+++ b/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisStreamLoadObserver.java
@@ -31,26 +31,28 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /** Doris Stream Load Observer. */
 public class DorisStreamLoadObserver
+        implements Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(DorisStreamLoadObserver.class);
 
@@ -63,10 +65,51 @@ public class DorisStreamLoadObserver
     private static final String RESULT_LABEL_ABORTED = "ABORTED";
     private static final String RESULT_LABEL_UNKNOWN = "UNKNOWN";
 
+    private final String basicAuthHeader;
+    private final List<String> hosts;
+    private final AtomicInteger hostIndex = new AtomicInteger(0);
+    private final Map<String, Long> hostCooldownUntil = new ConcurrentHashMap<>();
+    private final RequestConfig requestConfig;
+    private final CloseableHttpClient httpClient;
+
     /** Dorisstreamloadobserver. */
     public DorisStreamLoadObserver(DorisKey options)
     {
         this.options = options;
+        this.basicAuthHeader = "Basic " + new String(Base64.encodeBase64(
+                (options.getUsername() + ":" + options.getPassword()).getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8);
+        this.hosts = new ArrayList<>();
+        for (String host : options.getLoadUrlList()) {
+            this.hosts.add(host.startsWith("http://") || host.startsWith("https://") ? host : "http://" + host);
+        }
+        this.requestConfig = RequestConfig.custom()
+                .setConnectTimeout(options.getConnectTimeout())
+                .setSocketTimeout(options.getSocketTimeout())
+                .setConnectionRequestTimeout(options.getConnectionRequestTimeout())
+                .setRedirectsEnabled(true)
+                .build();
+
+        // One pooled client for the whole task: a client per batch pays a TCP handshake
+        // (plus a TLS handshake for https) for every single stream load.  The pool also
+        // ends up holding a connection per backend the FE redirects us to, so the limits
+        // are kept well above the number of configured hosts to never block on a lease.
+        PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+        connManager.setDefaultMaxPerRoute(Math.max(8, this.hosts.size() * 2));
+        connManager.setMaxTotal(Math.max(32, this.hosts.size() * 8));
+        this.httpClient = HttpClients.custom()
+                .setConnectionManager(connManager)
+                .setDefaultRequestConfig(this.requestConfig)
+                .setRedirectStrategy(new DefaultRedirectStrategy()
+                {
+                    @Override
+                    protected boolean isRedirectable(String method)
+                    {
+                        // Doris answers a stream load on the FE with a redirect to a BE
+                        return true;
+                    }
+                })
+                .build();
     }
 
     /** Urldecode. */
@@ -90,25 +133,37 @@ public class DorisStreamLoadObserver
     {
         String host = getLoadHost();
         if (host == null) {
-            throw new IOException("load_url cannot be empty, or the host cannot connect.Please check your configuration.");
+            throw new IOException("load_url cannot be empty, please check your configuration.");
         }
         String loadUrl = host + "/api/" + options.getDatabase() + "/" + options.getTable() + "/_stream_load";
         LOG.debug("Start to join batch data: rows[{}] bytes[{}] label[{}].", data.getRows().size(), data.getBytes(), data.getLabel());
         loadUrl = urlDecode(loadUrl);
-        Map<String, Object> loadResult = put(loadUrl, data.getLabel(), addRows(data.getRows(), data.getBytes().intValue()));
+        Map<String, Object> loadResult;
+        try {
+            loadResult = put(loadUrl, data.getLabel(), addRows(data.getRows(), data.getBytes().intValue()));
+        }
+        catch (IOException e) {
+            // connection level failure: stop sending the next batches to this host for a while
+            markHostFailure(host);
+            throw e;
+        }
         final String keyStatus = "Status";
         if (null == loadResult || !loadResult.containsKey(keyStatus)) {
+            markHostFailure(host);
             throw new IOException("Unable to flush data to Doris: unknown result status.");
         }
         LOG.debug("StreamLoad response:{}", JSON.toJSONString(loadResult));
         if (RESULT_FAILED.equals(loadResult.get(keyStatus))) {
+            markHostFailure(host);
             throw new IOException(
                     "Failed to flush data to Doris.\n" + JSON.toJSONString(loadResult)
             );
         }
         else if (RESULT_LABEL_EXISTED.equals(loadResult.get(keyStatus))) {
-            LOG.debug("StreamLoad response:{}", JSON.toJSONString(loadResult));
             checkStreamLoadState(host, data.getLabel());
+        }
+        else {
+            markHostSuccess(host);
         }
     }
 
@@ -121,40 +176,42 @@ public class DorisStreamLoadObserver
                 TimeUnit.SECONDS.sleep(Math.min(++idx, 5));
             }
             catch (InterruptedException ex) {
-                break;
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while checking the state of label " + label, ex);
             }
-            try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-                HttpGet httpGet = new HttpGet(host + "/api/" + options.getDatabase() + "/get_load_state?label=" + label);
-                httpGet.setHeader("Authorization", getBasicAuthHeader(options.getUsername(), options.getPassword()));
-                httpGet.setHeader("Connection", "close");
+            HttpGet httpGet = new HttpGet(host + "/api/" + options.getDatabase() + "/get_load_state?label=" + label);
+            httpGet.setHeader("Authorization", basicAuthHeader);
+            httpGet.setConfig(requestConfig);
 
-                try (CloseableHttpResponse resp = httpclient.execute(httpGet)) {
-                    HttpEntity respEntity = getHttpEntity(resp);
-                    if (respEntity == null) {
+            try (CloseableHttpResponse resp = httpClient.execute(httpGet)) {
+                HttpEntity respEntity = getHttpEntity(resp);
+                if (respEntity == null) {
+                    throw new IOException(String.format("Failed to flush data to Doris, Error " +
+                            "could not get the final state of label[%s].\n", label), null);
+                }
+                Map<String, Object> result = (Map<String, Object>) JSON.parse(EntityUtils.toString(respEntity, StandardCharsets.UTF_8));
+                String labelState = result == null ? null : (String) result.get("data");
+                if (null == labelState) {
+                    throw new IOException(String.format("Failed to flush data to Doris, Error " +
+                            "could not get the final state of label[%s]. response[%s]\n", label, JSON.toJSONString(result)), null);
+                }
+                LOG.info("Checking label[{}] state[{}]\n", label, labelState);
+                switch (labelState) {
+                    case LABEL_STATE_VISIBLE:
+                    case LABEL_STATE_COMMITTED:
+                        markHostSuccess(host);
+                        return;
+                    case RESULT_LABEL_PREPARE:
+                        continue;
+                    case RESULT_LABEL_ABORTED:
+                        markHostFailure(host);
+                        throw new DorisWriterException(String.format("Failed to flush data to Doris, Error " +
+                                "label[%s] state[%s]\n", label, labelState), null, true);
+                    case RESULT_LABEL_UNKNOWN:
+                    default:
+                        markHostFailure(host);
                         throw new IOException(String.format("Failed to flush data to Doris, Error " +
-                                "could not get the final state of label[%s].\n", label), null);
-                    }
-                    Map<String, Object> result = (Map<String, Object>) JSON.parse(EntityUtils.toString(respEntity));
-                    String labelState = (String) result.get("data");
-                    if (null == labelState) {
-                        throw new IOException(String.format("Failed to flush data to Doris, Error " +
-                                "could not get the final state of label[%s]. response[%s]\n", label, EntityUtils.toString(respEntity)), null);
-                    }
-                    LOG.info("Checking label[{}] state[{}]\n", label, labelState);
-                    switch (labelState) {
-                        case LABEL_STATE_VISIBLE:
-                        case LABEL_STATE_COMMITTED:
-                            return;
-                        case RESULT_LABEL_PREPARE:
-                            continue;
-                        case RESULT_LABEL_ABORTED:
-                            throw new DorisWriterException(String.format("Failed to flush data to Doris, Error " +
-                                    "label[%s] state[%s]\n", label, labelState), null, true);
-                        case RESULT_LABEL_UNKNOWN:
-                        default:
-                            throw new IOException(String.format("Failed to flush data to Doris, Error " +
-                                    "label[%s] state[%s]\n", label, labelState), null);
-                    }
+                                "label[%s] state[%s]\n", label, labelState), null);
                 }
             }
         }
@@ -195,91 +252,89 @@ public class DorisStreamLoadObserver
             throws IOException
     {
         LOG.debug("Executing stream load to: '{}', size: '{}'", loadUrl, data.length);
-        final HttpClientBuilder httpClientBuilder = HttpClients.custom()
-                .setRedirectStrategy(new DefaultRedirectStrategy()
-                {
-                    @Override
-                    protected boolean isRedirectable(String method)
-                    {
-                        return true;
-                    }
-                });
-        try (CloseableHttpClient httpclient = httpClientBuilder.build()) {
-            HttpPut httpPut = new HttpPut(loadUrl);
-            httpPut.removeHeaders(HttpHeaders.CONTENT_LENGTH);
-            httpPut.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
-            List<String> cols = options.getColumns();
-            if (null != cols && !cols.isEmpty() && options.isCsvFormat()) {
-                httpPut.setHeader("columns", cols.stream().map(f -> String.format("`%s`", f)).collect(Collectors.joining(",")));
-            }
-
-            options.loadProps2Map().forEach(httpPut::setHeader);
-
-            httpPut.setHeader("Expect", "100-continue");
-            httpPut.setHeader("label", label);
-            httpPut.setHeader("two_phase_commit", "false");
-            httpPut.setHeader("Authorization", getBasicAuthHeader(options.getUsername(), options.getPassword()));
-            httpPut.setEntity(new ByteArrayEntity(data));
-            httpPut.setConfig(RequestConfig.custom().setRedirectsEnabled(true).build());
-            try (CloseableHttpResponse resp = httpclient.execute(httpPut)) {
-                HttpEntity respEntity = getHttpEntity(resp);
-                if (respEntity == null) {
-                    return null;
-                }
-                return (Map<String, Object>) JSON.parse(EntityUtils.toString(respEntity));
-            }
+        HttpPut httpPut = new HttpPut(loadUrl);
+        httpPut.removeHeaders(HttpHeaders.CONTENT_LENGTH);
+        httpPut.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
+        List<String> cols = options.getColumns();
+        if (null != cols && !cols.isEmpty() && options.isCsvFormat()) {
+            httpPut.setHeader("columns", cols.stream().map(f -> String.format("`%s`", f)).collect(Collectors.joining(",")));
         }
-    }
 
-    private String getBasicAuthHeader(String username, String password)
-    {
-        String auth = username + ":" + password;
-        byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.UTF_8));
-        return "Basic " + new String(encodedAuth);
+        options.loadProps2Map().forEach(httpPut::setHeader);
+
+        httpPut.setHeader("Expect", "100-continue");
+        httpPut.setHeader("label", label);
+        httpPut.setHeader("two_phase_commit", "false");
+        httpPut.setHeader("Authorization", basicAuthHeader);
+        httpPut.setEntity(new ByteArrayEntity(data));
+        httpPut.setConfig(requestConfig);
+        try (CloseableHttpResponse resp = httpClient.execute(httpPut)) {
+            HttpEntity respEntity = getHttpEntity(resp);
+            if (respEntity == null) {
+                return null;
+            }
+            return (Map<String, Object>) JSON.parse(EntityUtils.toString(respEntity, StandardCharsets.UTF_8));
+        }
     }
 
     private HttpEntity getHttpEntity(CloseableHttpResponse resp)
+            throws IOException
     {
         int code = resp.getStatusLine().getStatusCode();
-        if (200 != code) {
-            LOG.warn("Request failed with code:{}", code);
-            return null;
+        if (code < 200 || code >= 300) {
+            String body = resp.getEntity() == null ? ""
+                    : EntityUtils.toString(resp.getEntity(), StandardCharsets.UTF_8);
+            throw new IOException("Stream load request failed with code=" + code + ", response=" + body);
         }
         HttpEntity respEntity = resp.getEntity();
         if (null == respEntity) {
-            LOG.warn("Request failed with empty response.");
+            LOG.warn("Request succeeded but the response body is empty.");
             return null;
         }
         return respEntity;
     }
 
+    /**
+     * Picks the next usable load host in round-robin order, skipping the hosts that are
+     * cooling down after a failure.  Previously every batch shuffled the host list and
+     * opened a throw-away TCP connection just to probe the first host.
+     */
     private String getLoadHost()
     {
-        List<String> hostList = options.getLoadUrlList();
-        Collections.shuffle(hostList);
-        // get the first available host
-        for (String host : hostList) {
-            String uri = "http://" + host;
-            if (checkConnection(uri)) {
-                return uri;
+        if (hosts.isEmpty()) {
+            return null;
+        }
+        long now = System.currentTimeMillis();
+        int size = hosts.size();
+        int start = Math.floorMod(hostIndex.getAndIncrement(), size);
+        for (int i = 0; i < size; i++) {
+            String host = hosts.get((start + i) % size);
+            Long coolingUntil = hostCooldownUntil.get(host);
+            if (coolingUntil == null || coolingUntil <= now) {
+                return host;
             }
         }
-        return null;
+        // no host is usable right now, trying one is still better than failing the batch
+        // outright: a connection error is retried by the caller against another host
+        String fallback = hosts.get(start);
+        LOG.warn("All Doris load hosts are cooling down, fallback to {}", fallback);
+        return fallback;
     }
 
-    private boolean checkConnection(String host)
+    private void markHostFailure(String host)
     {
-        try {
-            URL url = new URL(host);
-            HttpURLConnection co = (HttpURLConnection) url.openConnection();
-            co.setConnectTimeout(5000);
-            co.connect();
-            co.disconnect();
-            return true;
-        }
-        catch (Exception e1) {
-            LOG.warn("Failed to connect to host:{}", host);
-            return false;
-        }
+        hostCooldownUntil.put(host, System.currentTimeMillis() + options.getHostCooldownMs());
+    }
+
+    private void markHostSuccess(String host)
+    {
+        hostCooldownUntil.remove(host);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        httpClient.close();
     }
 }

--- a/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisWriterManager.java
+++ b/plugin/writer/doriswriter/src/main/java/com/wgzhao/addax/plugin/writer/doriswriter/DorisWriterManager.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /** Doris Writer Manager. */
@@ -47,57 +46,55 @@ public class DorisWriterManager {
     private final DorisStreamLoadObserver visitor;
     private final DorisKey options;
     private final List<byte[]> buffer = new ArrayList<> ();
+    private final LinkedBlockingDeque< WriterTuple > flushQueue;
+    private final ScheduledExecutorService scheduler;
     private int batchCount = 0;
     private long batchSize = 0;
     private volatile boolean closed = false;
     private volatile Throwable flushException;
-    private final LinkedBlockingDeque< WriterTuple > flushQueue;
-    private ScheduledExecutorService scheduler;
-    private ScheduledFuture<?> scheduledFuture;
 
     /** Doriswritermanager. */
     public DorisWriterManager( DorisKey options) {
         this.options = options;
         this.visitor = new DorisStreamLoadObserver (options);
         flushQueue = new LinkedBlockingDeque<>(options.getFlushQueueLength());
-        this.startScheduler();
+        BasicThreadFactory basicThreadFactory = BasicThreadFactory.builder().namingPattern("Doris-interval-flush").daemon(true).build();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(basicThreadFactory);
         this.startAsyncFlushing();
+        this.startScheduler();
     }
 
-    /** Startscheduler. */
-    public void startScheduler() {
-        stopScheduler();
-        BasicThreadFactory basicThreadFactory = BasicThreadFactory.builder().namingPattern("Doris-interval-flush").daemon(true).build();
-        this.scheduler = Executors.newScheduledThreadPool(1, basicThreadFactory);
-        this.scheduledFuture = this.scheduler.schedule(() -> {
+    /**
+     * Starts the interval flush, which is a single fixed-delay task for the whole life of
+     * the manager.  The previous implementation cancelled and rebuilt the scheduler around
+     * every stream load, which both spawned a thread pool per batch and could shut down the
+     * pool an interval task was being submitted to.
+     */
+    private void startScheduler() {
+        this.scheduler.scheduleWithFixedDelay(() -> {
             synchronized (DorisWriterManager.this) {
-                if (!closed) {
-                    try {
-                        String label = createBatchLabel();
-                        LOG.info("Doris interval Sinking triggered: label[{}].", label);
-                        if (batchCount == 0) {
-                            startScheduler();
-                        }
-                        flush(label, false);
-                    } catch (Throwable e) {
-                        flushException = e;
-                    }
+                if (closed || batchCount == 0) {
+                    return;
+                }
+                try {
+                    String label = createBatchLabel();
+                    LOG.debug("Doris interval Sinking triggered: rows[{}] bytes[{}] label[{}].", batchCount, batchSize, label);
+                    flush(label);
+                } catch (Throwable e) {
+                    flushException = e;
                 }
             }
-        }, options.getFlushInterval(), TimeUnit.MILLISECONDS);
-    }
-
-    /** Stopscheduler. */
-    public void stopScheduler() {
-        if (this.scheduledFuture != null) {
-            scheduledFuture.cancel(false);
-            this.scheduler.shutdown();
-        }
+        }, options.getFlushInterval(), options.getFlushInterval(), TimeUnit.MILLISECONDS);
     }
 
     /** Writerecord. */
     public final synchronized void writeRecord(String record) {
         checkFlushException();
+        if (closed) {
+            // the flush worker has already stopped, buffering now would silently drop data
+            throw AddaxException.asAddaxException(ErrorCode.EXECUTE_FAIL,
+                    new IOException("DorisWriterManager is already closed."));
+        }
         try {
             byte[] bts = record.getBytes(StandardCharsets.UTF_8);
             buffer.add(bts);
@@ -105,28 +102,27 @@ public class DorisWriterManager {
             batchSize += bts.length;
             if (batchCount >= options.getBatchSize()) {
                 String label = createBatchLabel();
-                LOG.debug("Doris buffer Sinking triggered: rows[{}] label[{}].", batchCount, label);
-                flush(label, false);
+                LOG.debug("Doris buffer Sinking triggered: rows[{}] bytes[{}] label[{}].", batchCount, batchSize, label);
+                flush(label);
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw AddaxException.asAddaxException(ErrorCode.EXECUTE_FAIL,
+                    new IOException("Interrupted while writing records to Doris.", e));
         } catch (Exception e) {
             throw AddaxException.asAddaxException(ErrorCode.EXECUTE_FAIL, e);
         }
     }
 
-    /** Flush. */
-    public synchronized void flush(String label, boolean waitUtilDone) throws Exception {
-        checkFlushException();
+    /**
+     * Enqueues the buffered records as one batch and starts a fresh one.  Blocks while the
+     * flush queue is full, which is what keeps the reader from outrunning the stream loads.
+     */
+    private synchronized void flush(String label) throws InterruptedException {
         if (batchCount == 0) {
-            if (waitUtilDone) {
-                waitAsyncFlushingDone();
-            }
             return;
         }
         flushQueue.put(new WriterTuple (label, batchSize,  new ArrayList<>(buffer)));
-        if (waitUtilDone) {
-            // wait the last flush
-            waitAsyncFlushingDone();
-        }
         buffer.clear();
         batchCount = 0;
         batchSize = 0;
@@ -134,14 +130,26 @@ public class DorisWriterManager {
 
     /** Close. */
     public synchronized void close() {
-        if (!closed) {
-            closed = true;
-            try {
+        if (closed) {
+            checkFlushException();
+            return;
+        }
+        closed = true;
+        scheduler.shutdown();
+        try {
+            if (batchCount > 0) {
                 String label = createBatchLabel();
-                if (batchCount > 0) LOG.debug("Doris Sink is about to close: label[{}].", label);
-                flush(label, true);
-            } catch (Exception e) {
-                throw new RuntimeException("Writing records to Doris failed.", e);
+                LOG.debug("Doris Sink is about to close: rows[{}] label[{}].", batchCount, label);
+                flush(label);
+            }
+            waitAsyncFlushingDone();
+        } catch (Exception e) {
+            throw new RuntimeException("Writing records to Doris failed.", e);
+        } finally {
+            try {
+                visitor.close();
+            } catch (IOException e) {
+                LOG.warn("Failed to close the Doris stream load http client.", e);
             }
         }
         checkFlushException();
@@ -154,14 +162,30 @@ public class DorisWriterManager {
 
     private void startAsyncFlushing() {
         // start flush thread
-        Thread flushThread = new Thread(new Runnable(){
-            public void run() {
-                while(true) {
-                    try {
-                        asyncFlush();
-                    } catch (Throwable e) {
-                        flushException = e;
+        Thread flushThread = new Thread(() -> {
+            while (true) {
+                WriterTuple flushData;
+                try {
+                    flushData = flushQueue.take();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (Strings.isNullOrEmpty(flushData.getLabel())) {
+                    // barrier enqueued by waitAsyncFlushingDone(): due to FIFO ordering,
+                    // all real batches enqueued before it have been stream-loaded
+                    if (flushData.getLatch() != null) {
+                        flushData.getLatch().countDown();
                     }
+                    if (closed) {
+                        return;
+                    }
+                    continue;
+                }
+                try {
+                    asyncFlush(flushData);
+                } catch (Throwable e) {
+                    flushException = e;
                 }
             }
         });
@@ -178,24 +202,14 @@ public class DorisWriterManager {
         checkFlushException();
     }
 
-    private void asyncFlush() throws Exception {
-        WriterTuple flushData = flushQueue.take();
-        if (Strings.isNullOrEmpty(flushData.getLabel())) {
-            // barrier reached, signal the waiting thread that all prior batches are done
-            if (flushData.getLatch() != null) {
-                flushData.getLatch().countDown();
-            }
-            return;
-        }
-        stopScheduler();
+    private void asyncFlush(WriterTuple flushData) throws Exception {
         LOG.debug("Async stream load: rows[{}] bytes[{}] label[{}].", flushData.getRows().size(), flushData.getBytes(), flushData.getLabel());
         for (int i = 0; i <= options.getMaxRetries(); i++) {
             try {
                 // flush to Doris with stream load
                 visitor.streamLoad(flushData);
                 LOG.debug("Async stream load finished: label[{}].", flushData.getLabel());
-                startScheduler();
-                break;
+                return;
             } catch (Exception e) {
                 LOG.warn("Failed to flush batch data to Doris, retry times = {}", i, e);
                 if (i >= options.getMaxRetries()) {

--- a/plugin/writer/doriswriter/src/main/resources/plugin_job_template.json
+++ b/plugin/writer/doriswriter/src/main/resources/plugin_job_template.json
@@ -8,6 +8,8 @@
       "col2"
     ],
     "batchSize": 102400,
+    "flushInterval": 3000,
+    "flushQueueLength": 1,
     "loadUrl": [
       "fe:fe_port"
     ],


### PR DESCRIPTION
## Summary

Reduce the fixed cost of every stream load batch in doriswriter and fix the flush lifecycle: reuse one pooled HTTP client per task instead of building a client and opening a probe connection for every batch, stop a broken FE from stalling the job, and stop the interval flusher from being cancelled and rebuilt around every batch.

Batching is deliberately **not** changed: `batchSize` keeps its meaning (max rows per stream load) and its default, matching every other writer in this project.

## Related Issue(s)

Relates to the DataX performance PR [alibaba/DataX#2353](https://github.com/alibaba/DataX/pull/2353). Only the parts that apply to this plugin are taken; see *Motivation and Context* for what was left out and why.

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [x] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- `DorisStreamLoadObserver`: one pooled `CloseableHttpClient` per task; the per-batch TCP pre-flight check is replaced by round-robin host selection with a cooldown after a failure; `get_load_state` polling reuses the pooled client; a non-2xx response is reported with its body instead of "unknown result status"; new timeouts are applied to every request.
- `DorisKey`: new `connectTimeout` (5000), `socketTimeout` (600000), `connectionRequestTimeout` (5000) and `hostCooldownMs` (30000).
- `DorisWriterManager`: one fixed-delay interval flush task for the lifetime of the manager instead of cancelling and rebuilding the scheduler around every stream load; the flush worker is stopped deterministically and the HTTP client closed in `close()`; writing after `close()` now fails loudly instead of buffering into a queue nobody drains.
- `plugin_job_template.json`: documents the new timeout keys.

## Motivation and Context

Compared with upstream DataX this plugin is the same code lineage, so it shares the per-batch inefficiencies PR #2353 targets:

1. **Connection reuse.** The old code built a new `CloseableHttpClient` for every batch and additionally opened a throw-away `HttpURLConnection` just to check that a host was reachable, so every batch paid two TCP handshakes (plus a TLS handshake for https). Both are gone.
2. **A dead FE would stall the job.** Host selection shuffled the list and probed hosts until one accepted a connection, and when none did the job failed. Now hosts are used round-robin, a failing host is skipped for `hostCooldownMs`, and if every host is cooling down the request is still issued and the batch level retry moves on to another host.
3. **Scheduler churn and a race.** `stopScheduler()`/`startScheduler()` ran around every stream load, spawning a thread pool per batch. It was also racy: the consumer thread restarted the scheduler without holding the manager monitor while the interval task could restart it under the monitor, so the field could point at a pool the other thread had just shut down and the next `schedule()` threw `RejectedExecutionException`, which was recorded as a flush failure and failed the task. A single fixed-delay task removes both problems, and the interval flush is no longer disabled for the whole duration of every stream load.
4. **No socket timeout.** A hung connection blocked the flush worker forever. Requests are now bounded by `connectTimeout` / `socketTimeout` / `connectionRequestTimeout`.

**Batching is unchanged.** An earlier revision of this PR also raised the default batch from 2048 rows to `maxBatchRows=100000` / `maxBatchSize=50MB`. It was reverted: `batchSize` is the batch parameter used by every other writer in this project (redis, paimon, iceberg, kafka, hdfs, es, clickhouse, the RDBMS family, ...) and always means rows, whereas `maxBatchRows`/`maxBatchSize` exist only in starrockswriter, and `batchSize` means *bytes* in the DataX doriswriter — introducing both names next to each other was a trap. Benchmarking on a real cluster (1M rows / 144MB, 2 channels) also showed no throughput difference between 2048-row and 100000-row batches, and the reader was not the bottleneck (a streamreader-to-local-file baseline of the same data finished in 9s against 24-30s end to end), so the batch size is not what limits this job.

Deliberately **not** taken from #2353:

- It deletes `DorisJsonCodec` while leaving the JSON branches in the factory and the manager, which breaks `format: json`; this plugin keeps JSON support.
- It makes the batch label final and drops the label recreation on `needReCreateLabel`, so a retry after `Label Already Exists` → `ABORTED` reuses the failing label and every retry is wasted.
- Its CSV escaping writes `\\n` (a Java `"\\\\n"`), i.e. an escaped backslash followed by a literal `n`, rather than the `\n` Doris needs. Missing CSV escaping is a real gap in this plugin — a field containing the column separator or a newline corrupts the row — but it needs its own change and its own verification against a cluster.

## How has this been tested?

- Automated tests: not applicable — this repository verifies plugins manually by design.
- Build: `mvn clean package -pl :doriswriter -DskipTests` (JDK 17) passes.
- Cluster benchmark, 1M rows / 144MB, 2 channels, DUPLICATE KEY table: 24s before vs 30s after on the first pair of runs, and no significant difference after repeated runs and further tuning of `batchSize` — the load path in that environment (~5-6MB/s) is the limit, not the number of transactions. A streamreader-only baseline of the same data in the same environment runs in 9s (111k rec/s), so the reader is not the constraint.
- Still to verify on a cluster:
  1. A job with an unreachable FE in `loadUrl` completes successfully and logs the cooldown fallback.
  2. The final batch is loaded and the process exits cleanly when the reader finishes.
  3. `format: json` still works (the JSON codec itself is untouched, but the factory path is exercised).
  4. `sliceRecordCount` that does not divide evenly by `batchSize`, verifying `COUNT(*)` exactly.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [ ] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [x] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.

## Release notes

doriswriter now reuses a pooled HTTP connection per task, no longer pays a TCP probe per batch, skips an unhealthy FE for a while instead of failing, and bounds every request with a configurable timeout. Batching behaviour is unchanged.

## Breaking changes / Migration

None. `batchSize`, `flushInterval`, `flushQueueLength` and `loadProps` keep their meaning and defaults; the new timeout keys are optional.
