### PR TITLE
fix(script): create missing remote directories during deploy

### DIFF
--- a/build-module.sh
+++ b/build-module.sh
@@ -25,28 +25,6 @@ set -e  # Exit on any error
 # gpg signing binds to the verify phase and needs a keyring; it only matters for
 # formal releases, so skip it for local installs
 export MAVEN_OPTS="-Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dgpg.skip=true "
-# if build for remote host, then skip all path exists check
-SKIP_CHECK=0
-
-function build_base() {
-    echo "Building base components..."
-    cd "$SRC_DIR"
-    # install (not package) so downstream single-module builds resolve these SNAPSHOTs from the local repo
-    mvn clean install -q -B -pl :addax-core,:addax-rdbms,:addax-storage -am || {
-        echo "Base build failed! Check dependencies and try again."
-        exit 1
-    }
-
-    # Ensure target directories exist
-    mkdir -p "${ADDAX_HOME}/lib"
-
-    # assembly output dir is named after the artifactId (addax-core-<version>)
-    rsync -a core/target/addax-core-${version}/* "${ADDAX_HOME}"
-    # list source paths explicitly: two brace groups would expand to a cross product
-    rsync -azv lib/addax-rdbms/target/addax-rdbms-${version}/lib/* \
-        lib/addax-storage/target/addax-storage-${version}/lib/* "${ADDAX_HOME}/lib/"
-    echo "Base build completed successfully"
-}
 
 # Set default directories if not provided
 if [ -z "$SRC_DIR" ]; then
@@ -60,6 +38,9 @@ if [ -z "$ADDAX_HOME" ]; then
    echo "Using default Addax home: $ADDAX_HOME"
 fi
 
+# Create a missing ADDAX_HOME without asking (non-interactive installs)
+ASSUME_YES=${ASSUME_YES:-false}
+
 # Get project version; the root pom has no <parent>, so the first <version> is ours.
 # Resolve against SRC_DIR so the script also works when invoked from any directory.
 version=$(awk -F'[<>]' '/<version>/ {print $3; exit}' "$SRC_DIR/pom.xml")
@@ -68,18 +49,194 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# deployment target helpers
+#
+# ADDAX_HOME is the Addax home path, ADDAX_TARGET is the rsync target pointing
+# at it: the path itself for a local install, "host:path" when REMOTE_HOST is set.
+# ---------------------------------------------------------------------------
+
+is_remote() {
+    [ -n "$REMOTE_HOST" ]
+}
+
+# Run a shell command on the deployment target.
+target_exec() {
+    if is_remote; then
+        ssh "$REMOTE_HOST" "$1"
+    else
+        bash -c "$1"
+    fi
+}
+
+# Check whether a directory exists on the deployment target.
+target_dir_exists() {
+    if is_remote; then
+        # ssh reports transport problems with 255, any other status is the remote
+        # test result, so the status has to be kept before it can be inspected
+        local rc=0
+        ssh "$REMOTE_HOST" "test -d '$1'" || rc=$?
+        if [ "$rc" -eq 255 ]; then
+            echo "Error: cannot run commands on $REMOTE_HOST (check ssh access and host key)" >&2
+            exit 1
+        fi
+        return "$rc"
+    fi
+    # a local install has no transport error to distinguish, the test result is
+    # the answer
+    [ -d "$1" ]
+}
+
+# Check whether a directory on the deployment target is writable, a read-only
+# install dir would otherwise only fail deep inside rsync
+target_dir_writable() {
+    if is_remote; then
+        ssh "$REMOTE_HOST" "test -w '$1'" 2>/dev/null
+    else
+        [ -w "$1" ]
+    fi
+}
+
+# Ask before creating a missing directory; without a terminal (ci, cron) create it
+# directly instead of hanging on a read that never gets an answer.
+confirm_create() {
+    if [ "$ASSUME_YES" = true ]; then
+        return 0
+    fi
+    if [ ! -t 0 ]; then
+        echo "$1 does not exist, creating it"
+        return 0
+    fi
+    local answer
+    read -r -p "$1 does not exist on ${REMOTE_HOST:-the local host}. Create it? [Y/n] " answer
+    case "$answer" in
+        [Nn]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Create a directory on the deployment target without asking, -p also creates the
+# whole parent chain which is what a first-time install needs
+ensure_target_dir() {
+    target_dir_exists "$1" && return 0
+    target_exec "mkdir -p '$1'" || {
+        echo "Failed to create $1 on ${REMOTE_HOST:-the local host}" >&2
+        return 1
+    }
+}
+
+# Make sure the Addax home exists on the deployment target. A fresh host usually
+# has no /opt/app/addax at all. Only the home itself is worth asking about, the
+# directories below it are part of its layout and are created without a prompt.
+ensure_home_dir() {
+    local home=$1
+    if target_dir_exists "$home"; then
+        if ! target_dir_writable "$home"; then
+            echo "Error: $home on ${REMOTE_HOST:-the local host} is not writable" >&2
+            return 1
+        fi
+        return 0
+    fi
+    if ! confirm_create "$home"; then
+        echo "Aborted: $home does not exist on the deployment target" >&2
+        return 1
+    fi
+    ensure_target_dir "$home" || return 1
+    echo "Created $home on ${REMOTE_HOST:-the local host}"
+}
+
+# Sync a path into the Addax home, recreating the directory layout below it.
+#
+# The staging root contains the layout Addax expects (bin/, lib/,
+# plugin/<type>/<name>), the second argument is the path to sync relative to that
+# root. rsync -R (relative) rebuilds the same path below the home on the receiving
+# side and creates every missing directory on the way, while a plain rsync only
+# creates the last component of the destination path. That is what makes
+# plugin/writer/<name> and lib land correctly on a first-time remote install.
+sync_into_home() {
+    local staging_root=$1
+    local rel_source=$2
+    shift 2
+    if [ ! -e "$staging_root/$rel_source" ]; then
+        echo "Error: $staging_root/$rel_source is missing, nothing to deploy" >&2
+        return 1
+    fi
+    # the ./ prefix keeps the implied path relative to the staging root instead of
+    # baking the absolute build directory into the remote path
+    (cd "$staging_root" && rsync -aR "$@" "./${rel_source}" "${ADDAX_TARGET}/") || {
+        echo "Error: rsync of $rel_source to ${ADDAX_TARGET} failed" >&2
+        return 1
+    }
+}
+
+# Mirror a directory into the Addax home, removing files that are gone from the
+# source. -R cannot be combined with --delete here: the implied parent directories
+# become part of the transfer and --delete then wipes every sibling plugin, so the
+# destination directory is created first and the sync stays inside it.
+sync_dir_into_home() {
+    local staging_root=$1
+    local rel_dir=$2
+    if [ ! -d "$staging_root/$rel_dir" ]; then
+        echo "Error: $staging_root/$rel_dir is missing, nothing to deploy" >&2
+        return 1
+    fi
+    ensure_target_dir "$ADDAX_HOME/$rel_dir" || return 1
+    rsync -az --delete "$staging_root/$rel_dir/" "$ADDAX_TARGET/$rel_dir/" || {
+        echo "Error: rsync of $rel_dir to ${ADDAX_TARGET}/$rel_dir failed" >&2
+        return 1
+    }
+}
+
+# Remove jars left over from a previous version, they would sit next to the new
+# one on the classpath otherwise.
+remove_stale_jars() {
+    local dir=$1
+    if ! target_dir_exists "$dir"; then
+        return 0
+    fi
+    # -not is used instead of ! so the command also works when run through ssh
+    target_exec "find '$dir' -maxdepth 1 -name '$2' -not -name '$3' -delete" 2>/dev/null || true
+}
+
+function build_base() {
+    echo "Building base components..."
+    cd "$SRC_DIR" || return 1
+    # install (not package) so downstream single-module builds resolve these SNAPSHOTs from the local repo
+    mvn clean install -q -B -pl :addax-core,:addax-rdbms,:addax-storage -am || {
+        echo "Base build failed! Check dependencies and try again."
+        return 1
+    }
+
+    # the assembly output dir is named after the artifactId (addax-core-<version>)
+    # and mirrors the Addax home layout; rsync creates the sub directories it
+    # transfers on its own, only the two destination roots have to exist
+    ensure_target_dir "$ADDAX_HOME/lib" || return 1
+    rsync -az "$SRC_DIR/core/target/addax-core-${version}/." "${ADDAX_TARGET}/" || {
+        echo "Failed to deploy core files to ${ADDAX_TARGET}" >&2
+        return 1
+    }
+    # list source paths explicitly: two brace groups would expand to a cross product
+    rsync -azv "$SRC_DIR/lib/addax-rdbms/target/addax-rdbms-${version}/lib/." \
+        "${ADDAX_TARGET}/lib/" || return 1
+    rsync -azv "$SRC_DIR/lib/addax-storage/target/addax-storage-${version}/lib/." \
+        "${ADDAX_TARGET}/lib/" || return 1
+    echo "Base build completed successfully"
+}
+
 # Parse options and module names (options come first, modules after)
 usage() {
-    echo "Usage: $0 [-s] module_name1 [module_name2 ...]"
+    echo "Usage: $0 [-y] [-s] module_name1 [module_name2 ...]"
     echo "  module_name: reader/writer plugin artifact id (e.g. streamreader, mysqlwriter),"
     echo "               or addax-core | server | addax-rdbms | addax-storage"
+    echo "  -y:          create a missing ADDAX_HOME without asking"
     echo "  -s:          sync only the module jar instead of the whole plugin directory"
-    echo "Env overrides: SRC_DIR, ADDAX_HOME, REMOTE_HOST"
+    echo "Env overrides: SRC_DIR, ADDAX_HOME, REMOTE_HOST, ASSUME_YES"
 }
 
 SYNC_JAR_ONLY=false
-while getopts ":hs" opt; do
+while getopts ":hsy" opt; do
     case "$opt" in
+        y) ASSUME_YES=true ;;
         s) SYNC_JAR_ONLY=true ;;
         h) usage; exit 0 ;;
         *) echo "Error: unknown option -$OPTARG" >&2; usage; exit 1 ;;
@@ -94,22 +251,18 @@ if [ ${#MODULES[@]} -eq 0 ]; then
 fi
 
 # Handle remote host case
+ADDAX_TARGET="${ADDAX_HOME}"
 if [ -n "${REMOTE_HOST}" ]; then
     echo "The building module(s) will upload to ${REMOTE_HOST}"
-    ADDAX_HOME="${REMOTE_HOST}:${ADDAX_HOME}"
-    SKIP_CHECK=1
+    ADDAX_TARGET="${REMOTE_HOST}:${ADDAX_HOME}"
 fi
 
 # Create necessary directories and build base if needed
-if [ $SKIP_CHECK -eq 0 ]; then
-    if [ ! -d "$ADDAX_HOME" ]; then
-        mkdir -p "$ADDAX_HOME" || { echo "Failed to create $ADDAX_HOME"; exit 1; }
-    fi
+ensure_home_dir "$ADDAX_HOME" || exit 1
 
-    if [ ! -d "$ADDAX_HOME/bin" ]; then
-        echo "Binary directory not found, building base components first"
-        build_base
-    fi
+if ! target_dir_exists "$ADDAX_HOME/bin"; then
+    echo "Binary directory not found, building base components first"
+    build_base || exit 1
 fi
 
 # Function to build and deploy a single module
@@ -118,7 +271,7 @@ build_module() {
     local SYNC_JAR_ONLY=$2
 
     echo "Building module: $MODULE_NAME"
-    cd "$SRC_DIR"
+    cd "$SRC_DIR" || return 1
     # avoid -am on the happy path: it rebuilds every upstream module on each iteration.
     # fall back to -am only when the module's SNAPSHOT deps are missing or stale.
     mvn clean install -B -q -pl :$MODULE_NAME || {
@@ -132,21 +285,24 @@ build_module() {
     # Handle special modules
     if [ "$MODULE_NAME" == "addax-core" ]; then
         echo "Deploying core module..."
-        rsync -av core/target/${MODULE_NAME}-${version}.jar ${ADDAX_HOME}/lib/
+        sync_into_home "$SRC_DIR/core/target/${MODULE_NAME}-${version}" \
+            "lib/${MODULE_NAME}-${version}.jar" -z || return 1
         echo "Core module deployed successfully"
         return 0
     fi
 
     if [ "$MODULE_NAME" == "server" ]; then
         echo "Deploying server module..."
-        rsync -av server/target/${MODULE_NAME}-${version}.jar ${ADDAX_HOME}/lib/
+        sync_into_home "$SRC_DIR/server/target/${MODULE_NAME}-${version}" \
+            "lib/${MODULE_NAME}-${version}.jar" -z || return 1
         echo "Server module deployed successfully"
         return 0
     fi
 
     if [ "$MODULE_NAME" == "addax-rdbms" ] || [ "$MODULE_NAME" == "addax-storage" ]; then
         echo "Deploying $MODULE_NAME module..."
-        rsync -av lib/${MODULE_NAME}/target/${MODULE_NAME}-${version}.jar ${ADDAX_HOME}/lib/
+        sync_into_home "$SRC_DIR/lib/${MODULE_NAME}/target/${MODULE_NAME}-${version}" \
+            "lib/${MODULE_NAME}-${version}.jar" -z || return 1
         echo "$MODULE_NAME module deployed successfully"
         return 0
     fi
@@ -161,31 +317,19 @@ build_module() {
         return 1
     fi
 
-    # Create target directory if needed
-    if [ $SKIP_CHECK -eq 0 ]; then
-        if [ ! -d "$ADDAX_HOME/$MODULE_DIR" ]; then
-            mkdir -p "$ADDAX_HOME/$MODULE_DIR" || {
-                echo "Failed to create $ADDAX_HOME/$MODULE_DIR";
-                return 1;
-            }
-        fi
-    fi
+    local STAGING_ROOT="$SRC_DIR/$MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}"
 
     # Deploy module
     if [ "$SYNC_JAR_ONLY" = true ]; then
         echo "Deploying only the jar file for $MODULE_NAME..."
-        if [ $SKIP_CHECK -eq 0 ]; then
-            # a stale jar of a previous version would land on the classpath next to the new one
-            find "$ADDAX_HOME/$MODULE_DIR/$MODULE_NAME" -maxdepth 1 \
-                -name "${MODULE_NAME}-*.jar" ! -name "${MODULE_NAME}-${version}.jar" -delete 2>/dev/null || true
-        fi
-        rsync -avz $MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}/$MODULE_DIR/${MODULE_NAME}/${MODULE_NAME}-${version}.jar \
-                $ADDAX_HOME/$MODULE_DIR/${MODULE_NAME}/
+        remove_stale_jars "$ADDAX_HOME/$MODULE_DIR/$MODULE_NAME" \
+            "${MODULE_NAME}-*.jar" "${MODULE_NAME}-${version}.jar"
+        sync_into_home "$STAGING_ROOT" \
+            "$MODULE_DIR/$MODULE_NAME/${MODULE_NAME}-${version}.jar" -z || return 1
     else
         echo "Deploying complete module directory for $MODULE_NAME..."
         # sync into the module's own dir so --delete never removes sibling plugins
-        rsync -avz --delete $MODULE_DIR/$MODULE_NAME/target/${MODULE_NAME}-${version}/$MODULE_DIR/${MODULE_NAME}/ \
-            $ADDAX_HOME/$MODULE_DIR/${MODULE_NAME}/
+        sync_dir_into_home "$STAGING_ROOT" "$MODULE_DIR/$MODULE_NAME" || return 1
     fi
 
     echo "Module $MODULE_NAME deployed successfully"
@@ -193,14 +337,21 @@ build_module() {
 }
 
 # Build each module
+FAILED=0
 for MODULE_NAME in "${MODULES[@]}"; do
     echo "========================================="
     echo "Processing module: $MODULE_NAME"
     echo "========================================="
     build_module "$MODULE_NAME" "$SYNC_JAR_ONLY" || {
-        echo "Failed to process module $MODULE_NAME"
+        echo "Failed to process module $MODULE_NAME" >&2
         # Continue with other modules even if one fails
+        FAILED=$((FAILED + 1))
     }
 done
+
+if [ "$FAILED" -gt 0 ]; then
+    echo "$FAILED module(s) failed" >&2
+    exit 1
+fi
 
 echo "All specified modules processed"


### PR DESCRIPTION
## Summary

Fix `build-module.sh` so a first-time deployment to a host where `ADDAX_HOME`
does not exist yet succeeds, and so a failed deploy is reported instead of being
swallowed.

## Related Issue(s)

None.

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- Detect the deployment target through remote-aware helpers (`target_exec`,
  `target_dir_exists`, `target_dir_writable`) so the same logic works for a
  local install and for `REMOTE_HOST=<host>`.
- Check `ADDAX_HOME` before deploying: prompt to create it recursively when it is
  missing, create it without asking with `-y` / `ASSUME_YES=true` or when there is
  no terminal (CI, cron), and fail early when it exists but is not writable.
  `ssh` transport failures now report a clear error instead of being treated as
  "directory missing".
- Deploy files with `rsync -aR ./<relative path> <target>/` from the staging root,
  which recreates `lib/` and `plugin/<type>/<name>/` including every missing
  parent directory on the receiver.
- Mirror a whole plugin directory with a plain `rsync -az --delete` into an
  explicitly created destination directory. `rsync -aR --delete` cannot be used
  there: the implied parent directories become part of the transfer and
  `--delete` then removes every sibling plugin below `plugin/writer`.
- Check the result of every `mvn`, `mkdir` and `rsync` call. `build_module` is
  invoked in a condition context, which disables `set -e` inside the function,
  so a failed deploy previously printed "deployed successfully" and the script
  exited 0.
- Report a clear error when the expected assembly output (staging directory) is
  missing, and exit non-zero when any module failed.

## Motivation and Context

Deploying to a fresh host failed with:

```
rsync: [Receiver] mkdir "/opt/app/addax/lib" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(800) [Receiver=3.2.7]
Core module deployed successfully
```

and for plugins:

```
rsync: [Receiver] mkdir "/opt/app/addax/plugin/writer/doriswriter" failed: No such file or directory (2)
```

Two independent problems caused this: rsync only creates the last component of
its destination path, so a missing parent chain fails, and the failure was
masked by the surrounding `||` handler that disables `set -e` in bash.

## How has this been tested?

No unit tests: the deployment flow was exercised end to end with a stubbed
`mvn`, a stubbed `ssh` (executing the remote command locally) and a stubbed
`rsync` that strips a fake `host:` prefix, which reproduces the remote code path
without touching a real server.

Manual steps:

1. Simulated remote install into a host without `ADDAX_HOME`:
   `REMOTE_HOST=fake ADDAX_HOME=<tmp>/home ./build-module.sh addax-core`
   - created the home, ran the base build, deployed `lib/addax-core-<version>.jar`
     plus `bin/`.
2. Plugin install into the same host:
   `REMOTE_HOST=fake ADDAX_HOME=<tmp>/home ./build-module.sh dwwriter`
   - created `plugin/writer/dwwriter/` recursively and deployed the whole
     plugin directory.
3. `-s` (jar only) run: plugin directory created, stale `dwwriter-*.jar` from a
   previous version removed, sibling plugins untouched.
4. Full directory sync with an existing sibling plugin: sibling survived, a stale
   file inside the module directory was removed by `--delete`.
5. Failure paths: missing staging directory and a simulated `rsync` exit 11 both
   abort with a non-zero exit status and no "deployed successfully" message.
6. Interactive prompt: answering `n` aborts before creating anything, pressing
   Enter creates the home and continues.

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [ ] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Checklist for maintainers / reviewers (recommended)

- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [ ] Evaluate whether the change requires a migration note.

## Release notes

`build-module.sh` can now deploy to a host where `ADDAX_HOME` does not exist yet,
and reports deploy failures with a non-zero exit status.

## Breaking changes / Migration

None. The existing invocation (`REMOTE_HOST=<host> ./build-module.sh <module>`)
keeps working; a missing `ADDAX_HOME` is now created after confirmation, or
without confirmation when `-y` / `ASSUME_YES=true` is set.

## Security

Not applicable.

## Additional context

Implementation detail worth knowing for reviewers: `rsync -aR --delete` is
intentionally avoided for directory mirroring. Reproduced locally:

```
# dest/plugin/writer/other/keep.jar is deleted
rsync -aR --delete ./plugin/writer/dw/ dest/
```
