### PR TITLE
fix(script): read installer prompts from the terminal so curl | bash works

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -336,6 +336,12 @@ ensure_java17_runtime() {
     abort "JDK 17 runtime not found. In NONINTERACTIVE mode, please install JDK 17 manually before running this script."
   fi
 
+  # Why: `curl ... | bash` feeds the script itself on stdin, so reading a prompt
+  # from stdin would silently swallow the next line of the script instead.
+  if [[ ! -r /dev/tty ]]; then
+    abort "JDK 17 runtime not found and no terminal is available to ask for permission. Please install JDK 17 manually and rerun this script."
+  fi
+
   echo "JDK 17 runtime was not detected on this system."
   if command -v java >/dev/null 2>&1; then
     current_java_major="$(get_java_major_version_from_bin "$(command -v java)" || true)"
@@ -344,7 +350,7 @@ ensure_java17_runtime() {
     fi
   fi
 
-  if ! read -r -p "Do you want this script to install JDK 17 now? [y/N] " response; then
+  if ! read -r -p "Do you want this script to install JDK 17 now? [y/N] " response 2>/dev/null </dev/tty; then
     response="n"
   fi
 
@@ -429,15 +435,21 @@ if [[ -d "${ADDAX_REPOSITORY}" ]]; then
     abort "NONINTERACTIVE mode detected: refusing to reinstall automatically. Remove ${ADDAX_REPOSITORY} manually and retry."
   fi
 
+  # Why: Same as the JDK prompt below — under `curl ... | bash` stdin is the
+  # script itself, so the prompt must come from the terminal instead.
+  if [[ ! -r /dev/tty ]]; then
+    abort "No terminal is available to ask for confirmation. Remove ${ADDAX_REPOSITORY} manually and retry."
+  fi
+
   echo "Do you want to reinstall? This script will clean up ${ADDAX_REPOSITORY}."
   response=""
-  if ! read -r -p "Do you want to continue? [y/N] " response; then
+  if ! read -r -p "Do you want to continue? [y/N] " response 2>/dev/null </dev/tty; then
     response="n"
   fi
 
   response="$(printf "%s" "${response}" | tr '[:upper:]' '[:lower:]')"
   if [[ "${response}" != "y" ]]; then
-    exit 1
+    abort "Reinstall declined. Nothing was changed."
   fi
 
   safe_remove_repository "${ADDAX_REPOSITORY}"


### PR DESCRIPTION
## Summary

Make the advertised `curl -fsSL .../install.sh | bash` install actually work. Under
that mode stdin is the script itself, so both interactive `read` prompts silently
consumed the next line of the script instead of waiting for an answer. The script is
now fully functional when piped, on macOS and Linux.

## Related Issue(s)

None. Discovered while reviewing `install.sh` for `curl | bash` correctness.

## What type of change is this?

- [x] Bugfix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [ ] Chore / Refactor
- [ ] Breaking change (changes API or runtime behavior)

## Changes

- Read the reinstall-confirmation prompt and the JDK 17 install-consent prompt from
  `/dev/tty` (with stderr redirected) instead of stdin.
- Abort with an explicit message when no controlling terminal is available, so
  unattended runs (CI, cron, `ssh -T`, `docker run` without `-t`) fail loudly rather
  than running with unpredictable behavior.
- Replace `exit 1` on a declined reinstall with an abort that reports nothing was
  changed, so a user-initiated cancel is no longer indistinguishable from a failure.

## Motivation and Context

`install.sh` refers to itself as an installable script, but piping it through bash
breaks every interactive path:

1. bash reads the script from stdin, so the next token of stdin is the rest of the
   script, not the user's typing.
2. `read -r -p "..." response` therefore never shows a prompt: it consumes the
   following line of the script. Reproduced with a minimal case — the line after the
   `read` was swallowed and never executed, with exit status 0 and no error.

In practice this means a user running the documented one-liner could never confirm or
decline the reinstall prompt, and the JDK 17 consent prompt was equally unreachable.
The installer continued past both, silently skipping a line of itself each time.

Reading from `/dev/tty` rather than stdin is the standard fix for installers that must
work both as `./install.sh` and as `curl ... | bash`. `sudo` is unaffected by this
change, since it already prompts on the terminal.

## How has this been tested?

No automated tests exist for this shell script; verification was manual, on macOS.

1. `bash -n install.sh` — passes.
2. `printf 'n\nn\n' | bash -c 'cat install.sh | bash'` — the script parses in full and
   reaches the sudo-access check, confirming no line is now consumed by a prompt.
3. Minimal reproduction of the prompt pattern with a piped stdin: the `/dev/tty`
   variant returns the supplied answer and the following line still executes; the
   original stdin variant swallowed it.
4. Verified the release asset layout matches the extraction step: `package.xml` sets
   `includeBaseDirectory=false`, so the tarball top level is `bin/conf/lib` and
   `tar -xzf ... --strip-components 1` lands the launcher at `${ADDAX_REPOSITORY}/bin/addax.sh`
   as `configure_addax_java_launcher` expects. The `addax-${version}.tar.gz` asset name
   matches what `get_latest_release` builds.

Not tested end-to-end: a full install writes to `/opt/addax` and requires an interactive
`sudo` prompt, so it was not run during review. Reviewers should exercise the one-liner
on a clean machine before merge:

```bash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/wgzhao/Addax/<branch>/install.sh)"
```

## Checklist (required)

- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable). — N/A, shell script; manual
      verification described above.
- [x] I ran a local build and fixed any compilation issues. — N/A, no Java or build
      inputs touched.
- [x] I updated or added documentation if needed (README, docs/ or docs/en/). — N/A.
- [x] I updated CHANGELOG.md when appropriate. — N/A, the repository has no CHANGELOG.md.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [x] I added the `Signed-off-by` line in the final commit message if required by the
      project. — Not required by the project's commit lint rules.

## Checklist for maintainers / reviewers (recommended)

- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [ ] Evaluate whether the change requires a migration note.

## Release notes

Fixed `install.sh` so the documented `curl ... | bash` one-liner works: interactive
prompts now read from the terminal instead of consuming the script's own stdin, and
unattended runs without a terminal abort with a clear message instead of proceeding
unpredictably.

## Breaking changes / Migration

None.

## Security

No security-relevant behavior is changed. The script's existing download and sudo
handling are untouched.