### PR TITLE
fix(plugin-streamreader): drop the shared increment state and rework the column model

### DIFF
--- a/plugin/reader/streamreader/pom.xml
+++ b/plugin/reader/streamreader/pom.xml
@@ -38,11 +38,6 @@
             <groupId>com.wgzhao.addax</groupId>
             <artifactId>addax-core</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-rng-simple</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/ColumnSpec.java
+++ b/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/ColumnSpec.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wgzhao.addax.plugin.reader.streamreader;
+
+import com.wgzhao.addax.core.base.Constant;
+import com.wgzhao.addax.core.base.Key;
+import com.wgzhao.addax.core.element.BoolColumn;
+import com.wgzhao.addax.core.element.BytesColumn;
+import com.wgzhao.addax.core.element.Column;
+import com.wgzhao.addax.core.element.DateColumn;
+import com.wgzhao.addax.core.element.DoubleColumn;
+import com.wgzhao.addax.core.element.LongColumn;
+import com.wgzhao.addax.core.element.StringColumn;
+import com.wgzhao.addax.core.element.TimestampColumn;
+import com.wgzhao.addax.core.exception.AddaxException;
+import com.wgzhao.addax.core.util.Configuration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.random.RandomGenerator;
+
+import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
+import static com.wgzhao.addax.core.spi.ErrorCode.NOT_SUPPORT_TYPE;
+import static com.wgzhao.addax.core.spi.ErrorCode.REQUIRED_VALUE;
+
+/**
+ * The generation rule of one column.
+ * <p>
+ * A column is parsed and validated exactly once - by {@link StreamReader.Job} to fail fast on a bad
+ * configuration, and by {@link StreamReader.Task} to build the records - and the resulting rule is
+ * applied to every record afterwards, so that no configuration item is read on the hot path.
+ *
+ * @param type the type of the column
+ * @param rule how the value of the column is produced
+ */
+public record ColumnSpec(Type type, Rule rule)
+{
+    /** The supported column types. */
+    public enum Type
+    {
+        STRING, LONG, BOOL, DOUBLE, DATE, BYTES, TIMESTAMP
+    }
+
+    /** How the value of a column is produced. */
+    public sealed interface Rule
+    {
+    }
+
+    /**
+     * A fixed value, taken from the {@code value} item.
+     *
+     * @param value the raw value
+     * @param dateMillis the parsed value of a {@link Type#DATE} column, 0 for the other types
+     */
+    public record ConstantValue(String value, long dateMillis) implements Rule
+    {
+    }
+
+    /**
+     * A random value taken from the inclusive range [{@code min}, {@code max}].
+     * The bounds are lengths for a {@link Type#STRING}/{@link Type#BYTES} column and the ratio of
+     * false to true for a {@link Type#BOOL} column.
+     *
+     * @param min the lower bound
+     * @param max the upper bound
+     * @param scale the number of decimal places of a {@link Type#DOUBLE} value, -1 if unset
+     */
+    public record Random(long min, long max, int scale) implements Rule
+    {
+    }
+
+    /**
+     * An arithmetic sequence of a {@link Type#LONG} column, the value is {@code start + n * step},
+     * where {@code n} is the ordinal of the record inside the whole job.
+     */
+    public record Increment(long start, long step) implements Rule
+    {
+    }
+
+    /**
+     * A date sequence of a {@link Type#DATE} column, the value is
+     * {@code base + n * step * unit}, where {@code n} is the ordinal of the record inside the whole job.
+     *
+     * @param baseMillis the start date, in epoch milliseconds
+     */
+    public record DateIncrement(long baseMillis, long step, ChronoUnit unit) implements Rule
+    {
+    }
+
+    /** The value that stands for a SQL NULL. */
+    private static final String NULL_VALUE = "null";
+
+    /** The random range of a {@link Type#TIMESTAMP} column. */
+    private static final long TIMESTAMP_LOWER_BOUND = 1_100_000_000_000L;
+    private static final long TIMESTAMP_UPPER_BOUND = 2_100_000_000_000L;
+
+    /** The interval units accepted by the increment function of a date column. */
+    private static final String UNIT_HINT = "d/day, M/month, y/year, h/hour, m/minute, s/second, w/week";
+    private static final Map<String, ChronoUnit> DATE_UNITS = Map.ofEntries(
+            Map.entry("d", ChronoUnit.DAYS),
+            Map.entry("day", ChronoUnit.DAYS),
+            Map.entry("M", ChronoUnit.MONTHS),
+            Map.entry("month", ChronoUnit.MONTHS),
+            Map.entry("y", ChronoUnit.YEARS),
+            Map.entry("year", ChronoUnit.YEARS),
+            Map.entry("w", ChronoUnit.WEEKS),
+            Map.entry("week", ChronoUnit.WEEKS),
+            Map.entry("h", ChronoUnit.HOURS),
+            Map.entry("hour", ChronoUnit.HOURS),
+            Map.entry("m", ChronoUnit.MINUTES),
+            Map.entry("minute", ChronoUnit.MINUTES),
+            Map.entry("s", ChronoUnit.SECONDS),
+            Map.entry("second", ChronoUnit.SECONDS));
+
+    /**
+     * Parse and validate the configuration of one column.
+     *
+     * @param column the configuration of the column
+     * @return the generation rule of the column
+     */
+    public static ColumnSpec parse(Configuration column)
+    {
+        Type type = parseType(column.getString(Key.TYPE));
+        String dateFormat = Type.DATE == type
+                ? column.getString(Key.DATE_FORMAT, Constant.DEFAULT_DATE_FORMAT)
+                : null;
+
+        String random = column.getString(StreamConstant.RANDOM);
+        if (StringUtils.isNotBlank(random)) {
+            return new ColumnSpec(type, parseRandom(type, dateFormat, random));
+        }
+
+        String incr = column.getString(StreamConstant.INCR);
+        if (StringUtils.isNotBlank(incr)) {
+            return new ColumnSpec(type, parseIncrement(type, dateFormat, incr));
+        }
+
+        String value = column.getNecessaryValue(Key.VALUE, REQUIRED_VALUE);
+        long dateMillis = Type.DATE == type ? parseDate(value, dateFormat).getTime() : 0L;
+        return new ColumnSpec(type, new ConstantValue(value, dateMillis));
+    }
+
+    /**
+     * Build the column of the record whose ordinal inside the whole job is {@code ordinal}.
+     *
+     * @param ordinal the ordinal of the record inside the whole job
+     * @param rng the random generator of the task
+     * @return the column of the record
+     */
+    public Column toColumn(long ordinal, RandomGenerator rng)
+    {
+        if (this.rule instanceof ConstantValue constant) {
+            return constantColumn(constant);
+        }
+        if (this.rule instanceof Random random) {
+            return randomColumn(random, rng);
+        }
+        if (this.rule instanceof Increment increment) {
+            return new LongColumn(increment.start() + ordinal * increment.step());
+        }
+        if (this.rule instanceof DateIncrement increment) {
+            Date date = Date.from(Instant.ofEpochMilli(increment.baseMillis())
+                    .atZone(ZoneId.systemDefault())
+                    .plus(ordinal * increment.step(), increment.unit())
+                    .toInstant());
+            return new DateColumn(date);
+        }
+        throw new IllegalStateException("The rule " + this.rule + " is not supported.");
+    }
+
+    private Column constantColumn(ConstantValue constant)
+    {
+        if (NULL_VALUE.equals(constant.value())) {
+            return new StringColumn();
+        }
+        return switch (this.type) {
+            case STRING -> new StringColumn(constant.value());
+            case LONG -> new LongColumn(constant.value());
+            case DOUBLE -> new DoubleColumn(constant.value());
+            case BOOL -> new BoolColumn(Boolean.parseBoolean(constant.value()));
+            case DATE -> new DateColumn(new Date(constant.dateMillis()));
+            case BYTES -> new BytesColumn(constant.value().getBytes(StandardCharsets.UTF_8));
+            case TIMESTAMP -> new TimestampColumn(constant.value());
+        };
+    }
+
+    private Column randomColumn(Random random, RandomGenerator rng)
+    {
+        return switch (this.type) {
+            case STRING -> new StringColumn(RandomStringUtils.insecure().nextAlphanumeric(nextLength(random, rng)));
+            case BYTES -> new BytesColumn(RandomStringUtils.insecure().nextAlphanumeric(nextLength(random, rng))
+                    .getBytes(StandardCharsets.UTF_8));
+            case LONG -> new LongColumn(rng.nextLong(random.min(), random.max() + 1));
+            case DOUBLE -> new DoubleColumn(nextDouble(random, rng));
+            case DATE -> new DateColumn(new Date(rng.nextLong(random.min(), random.max() + 1)));
+            case BOOL -> new BoolColumn(nextBool(random, rng));
+            // the configured bounds are meaningless for a timestamp, a reasonable range is used instead
+            case TIMESTAMP -> new TimestampColumn(rng.nextLong(TIMESTAMP_LOWER_BOUND, TIMESTAMP_UPPER_BOUND));
+        };
+    }
+
+    private static int nextLength(Random random, RandomGenerator rng)
+    {
+        return (int) rng.nextLong(random.min(), random.max() + 1);
+    }
+
+    private static double nextDouble(Random random, RandomGenerator rng)
+    {
+        double value = rng.nextDouble(random.min(), random.max() + 1);
+        if (random.scale() > 0) {
+            return BigDecimal.valueOf(value).setScale(random.scale(), RoundingMode.HALF_UP).doubleValue();
+        }
+        return value;
+    }
+
+    private static boolean nextBool(Random random, RandomGenerator rng)
+    {
+        // the bounds are the ratio of false to true, so `random 0, 10` never yields false
+        if (0 == random.min()) {
+            return true;
+        }
+        if (0 == random.max()) {
+            return false;
+        }
+        // min + max outcomes, `max` of them are true
+        return rng.nextLong(0, random.min() + random.max()) >= random.min();
+    }
+
+    private static Type parseType(String typeName)
+    {
+        if (StringUtils.isBlank(typeName)) {
+            return Type.STRING;
+        }
+        try {
+            return Type.valueOf(typeName.trim().toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e) {
+            throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
+                    String.format("The column type [%s] is unsupported.", typeName));
+        }
+    }
+
+    private static Rule parseRandom(Type type, String dateFormat, String random)
+    {
+        String[] fields = random.split(",");
+        if (fields.length < 2 || fields.length > 3) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("Illegal random value [%s], the supported form is 'minVal, maxVal[, scale]'.", random));
+        }
+
+        long min;
+        long max;
+        if (Type.DATE == type) {
+            min = parseDate(fields[0].trim(), dateFormat).getTime();
+            max = parseDate(fields[1].trim(), dateFormat).getTime();
+        }
+        else {
+            min = parseLong(fields[0], StreamConstant.RANDOM);
+            max = parseLong(fields[1], StreamConstant.RANDOM);
+            if (min < 0 || max < 0) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                        String.format("The random function's params [%s,%s] can not be negative.", fields[0], fields[1]));
+            }
+        }
+        if (min > max && Type.BOOL != type) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("The random function's params [%s,%s] is not valid, "
+                            + "the first param must not be greater than the second one.", fields[0], fields[1]));
+        }
+        checkBounds(type, min, max);
+
+        int scale = -1;
+        if (3 == fields.length) {
+            long parsedScale = parseLong(fields[2], "scale");
+            if (parsedScale < 0 || parsedScale > Integer.MAX_VALUE) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                        String.format("The scale [%s] is out of range.", fields[2].trim()));
+            }
+            scale = (int) parsedScale;
+        }
+        return new Random(min, max, scale);
+    }
+
+    private static void checkBounds(Type type, long min, long max)
+    {
+        // max + 1 is used as the exclusive upper bound of every random range
+        if (Long.MAX_VALUE == max) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    "The random function's second param is too large.");
+        }
+        // a length or a ratio is consumed as an int, a value range is not
+        if (Type.LONG != type && Type.DOUBLE != type && Type.DATE != type
+                && (min > Integer.MAX_VALUE || max > Integer.MAX_VALUE)) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("The random function's params [%d,%d] are too large for a %s column.", min, max, type));
+        }
+    }
+
+    private static Rule parseIncrement(Type type, String dateFormat, String incr)
+    {
+        String[] fields = incr.split(",");
+        if (Type.LONG == type) {
+            if (fields.length > 2) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                        String.format("Illegal incr value [%s], the supported form is 'startVal[, step]'.", incr));
+            }
+            long step = 2 == fields.length ? parseLong(fields[1], StreamConstant.INCR) : 1L;
+            return new Increment(parseLong(fields[0], StreamConstant.INCR), step);
+        }
+        if (Type.DATE == type) {
+            if (fields.length > 3) {
+                throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                        String.format("Illegal incr value [%s], the supported form is 'startDate[, step[, unit]]'.", incr));
+            }
+            long step = 2 <= fields.length && StringUtils.isNotBlank(fields[1])
+                    ? parseLong(fields[1], StreamConstant.INCR)
+                    : 1L;
+            ChronoUnit unit = 3 == fields.length && StringUtils.isNotBlank(fields[2])
+                    ? parseUnit(fields[2])
+                    : ChronoUnit.DAYS;
+            return new DateIncrement(parseDate(fields[0].trim(), dateFormat).getTime(), step, unit);
+        }
+        throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
+                String.format("The %s type can not support the increment function.", type));
+    }
+
+    private static ChronoUnit parseUnit(String unit)
+    {
+        ChronoUnit chronoUnit = DATE_UNITS.get(unit.trim());
+        if (null == chronoUnit) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("The interval unit [%s] is not valid, the supported units are %s", unit.trim(), UNIT_HINT));
+        }
+        return chronoUnit;
+    }
+
+    private static long parseLong(String field, String item)
+    {
+        try {
+            return Long.parseLong(field.trim());
+        }
+        catch (NumberFormatException e) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("The %s item must be numeric, but got [%s].", item, field.trim()));
+        }
+    }
+
+    private static Date parseDate(String value, String dateFormat)
+    {
+        try {
+            TemporalAccessor parsed = DateTimeFormatter.ofPattern(dateFormat).parse(value);
+            LocalTime time = parsed.query(TemporalQueries.localTime());
+            LocalDateTime dateTime = LocalDateTime.of(LocalDate.from(parsed), null == time ? LocalTime.MIDNIGHT : time);
+            return Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
+        }
+        catch (DateTimeException e) {
+            throw AddaxException.asAddaxException(ILLEGAL_VALUE,
+                    String.format("The date value [%s] does not match the date format [%s].", value, dateFormat), e);
+        }
+    }
+}

--- a/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/StreamConstant.java
+++ b/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/StreamConstant.java
@@ -19,32 +19,20 @@
 
 package com.wgzhao.addax.plugin.reader.streamreader;
 
-import com.wgzhao.addax.core.base.Constant;
-
 /** Stream Constant configuration keys. */
-public final class StreamConstant extends Constant
+public final class StreamConstant
 {
-
-    /** Random. */
+    /** The random function of a column. */
     public static final String RANDOM = "random";
 
-    // 递增字段
-    /** Incr. */
+    /** The increment function of a column. */
     public static final String INCR = "incr";
 
+    /** The ordinal of a slice inside the whole job, injected by {@link StreamReader.Job#split}. */
+    public static final String SLICE_INDEX = "sliceIndex";
 
-    /** Have mixup function. */
-    public static final String HAVE_MIXUP_FUNCTION = "hasMixupFunction";
-    /** Mixup function pattern. */
-    public static final String MIXUP_FUNCTION_PATTERN = "\\s*(.*)\\s*,\\s*(.*)\\s*";
-    /** Mixup function param1. */
-    public static final String MIXUP_FUNCTION_PARAM1 = "mixupParam1";
-    /** Mixup function param2. */
-    public static final String MIXUP_FUNCTION_PARAM2 = "mixupParam2";
-    /** Mixup function scale. */
-    public static final String MIXUP_FUNCTION_SCALE = "scale";
-    /** Have incr function. */
-    public static final String HAVE_INCR_FUNCTION = "hasIncrFunction";
+    /** The number of slices of the whole job, injected by {@link StreamReader.Job#split}. */
+    public static final String SLICE_COUNT = "sliceCount";
 
     private StreamConstant() {}
 }

--- a/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/StreamReader.java
+++ b/plugin/reader/streamreader/src/main/java/com/wgzhao/addax/plugin/reader/streamreader/StreamReader.java
@@ -19,75 +19,34 @@
 
 package com.wgzhao.addax.plugin.reader.streamreader;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.wgzhao.addax.core.base.Key;
-import com.wgzhao.addax.core.element.BoolColumn;
-import com.wgzhao.addax.core.element.BytesColumn;
-import com.wgzhao.addax.core.element.Column;
-import com.wgzhao.addax.core.element.DateColumn;
-import com.wgzhao.addax.core.element.DoubleColumn;
-import com.wgzhao.addax.core.element.LongColumn;
 import com.wgzhao.addax.core.element.Record;
-import com.wgzhao.addax.core.element.StringColumn;
-import com.wgzhao.addax.core.element.TimestampColumn;
 import com.wgzhao.addax.core.exception.AddaxException;
 import com.wgzhao.addax.core.plugin.RecordSender;
 import com.wgzhao.addax.core.spi.Reader;
 import com.wgzhao.addax.core.util.Configuration;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
-import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.simple.RandomSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.random.RandomGenerator;
 
 import static com.wgzhao.addax.core.spi.ErrorCode.ILLEGAL_VALUE;
-import static com.wgzhao.addax.core.spi.ErrorCode.NOT_SUPPORT_TYPE;
 import static com.wgzhao.addax.core.spi.ErrorCode.REQUIRED_VALUE;
 
 /** Stream Reader. */
 public class StreamReader
         extends Reader
 {
-
-    private enum Type
-    {
-        STRING, LONG, BOOL, DOUBLE, DATE, BYTES, TIMESTAMP,
-        ;
-
-        private static boolean isTypeIllegal(String typeString)
-        {
-            try {
-                Type.valueOf(typeString.toUpperCase());
-            }
-            catch (Exception e) {
-                return false;
-            }
-
-            return true;
-        }
-    }
-
     /** Job. */
     public static class Job
             extends Reader.Job
     {
-
         private static final Logger LOG = LoggerFactory.getLogger(Job.class);
+
         private Configuration originalConfig;
-        private static final Set<String> validUnits = Set.of("d", "day", "M", "month", "y", "year", "h", "hour", "m", "minute", "s", "second", "w", "week");
 
         @Override
         public void init()
@@ -106,272 +65,71 @@ public class StreamReader
             }
         }
 
+        /**
+         * Validate every column and normalize it into the form that the tasks consume.
+         * The column is parsed here as well, so that an illegal configuration fails the job
+         * before any task is started.
+         *
+         * @param originalConfig the configuration of the job
+         */
         private void dealColumn(Configuration originalConfig)
         {
-            List<JSONObject> columns = originalConfig.getList(Key.COLUMN, JSONObject.class);
-            if (null == columns || columns.isEmpty()) {
+            List<Configuration> columns = originalConfig.getListConfiguration(Key.COLUMN);
+            if (columns.isEmpty()) {
                 throw AddaxException.asAddaxException(REQUIRED_VALUE,
                         "The item column is required.");
             }
 
-            List<String> dealColumns = new ArrayList<>();
-            for (JSONObject eachColumn : columns) {
-                Configuration eachColumnConfig = Configuration.from(eachColumn);
-                try {
-                    this.parseMixUpFunctions(eachColumnConfig);
-                }
-                catch (Exception e) {
-                    throw AddaxException.asAddaxException(NOT_SUPPORT_TYPE,
-                            String.format("Failed to parse mix up functions [%s]", e.getMessage()), e);
-                }
-
-                String typeName = eachColumnConfig.getString(Key.TYPE);
-                if (StringUtils.isBlank(typeName)) {
-                    // empty typeName will be set to default type: string
-                    eachColumnConfig.set(Key.TYPE, Type.STRING);
-                }
-                else {
-                    if (Type.DATE.name().equalsIgnoreCase(typeName)) {
-                        boolean notAssignDateFormat = StringUtils
-                                .isBlank(eachColumnConfig.getString(Key.DATE_FORMAT));
-                        if (notAssignDateFormat) {
-                            eachColumnConfig.set(Key.DATE_FORMAT, StreamConstant.DEFAULT_DATE_FORMAT);
-                        }
-                    }
-                    if (!Type.isTypeIllegal(typeName)) {
-                        throw AddaxException.asAddaxException(
-                                NOT_SUPPORT_TYPE,
-                                String.format("The [%s] is unsupported.", typeName));
-                    }
-                }
-                dealColumns.add(eachColumnConfig.toJSON());
+            List<String> normalizedColumns = new ArrayList<>(columns.size());
+            for (Configuration eachColumn : columns) {
+                removeConflictedItems(eachColumn);
+                ColumnSpec.parse(eachColumn);
+                normalizedColumns.add(eachColumn.toJSON());
             }
-
-            originalConfig.set(Key.COLUMN, dealColumns);
+            originalConfig.set(Key.COLUMN, normalizedColumns);
         }
 
         /**
-         * Supports random functions, examples are as follows:
-         * LONG: random 0, 10 - random number between 0 and 10
-         * STRING: random 0, 10 - random string with length between 0 and 10
-         * BOOL: random 0, 10 - ratio of false and true
-         * DOUBLE: random 0, 10 - random floating-point number between 0 and 10
-         * DOUBLE: random 0, 10, 2 - random floating-point number between 0 and 10 with 2 decimal places
-         * DATE: random 2014-07-07 00:00:00, 2016-07-07 00:00:00 - random date between start and end time,
-         * default date format (comma not supported) is yyyy-MM-dd HH:mm:ss
-         * BYTES: random 0, 10 - random string with length between 0 and 10, encoded in UTF-8 binary
-         * When a mixup function is configured, value can be omitted
-         * If neither is configured
-         * Supports increment functions, currently only supports integer types, examples are as follows:
-         * LONG: incr 100 - starts from 100, increments by 1 each time
-         * LONG: incr 0, 1 - starts from 0, increments by 1 each time
-         * LONG: incr 1, 10 - starts from 1, increments by 10 each time
-         * LONG: incr 1000, 1 - starts from 1000, increments by -1 each time, allowing negative values
-         * DATE: incr &lt;date from&gt; &lt;interval&gt; &lt;unit&gt;
-         * date from: specifies the start date, required
-         * interval: interval period, default is 1, negative values decrement, optional
-         * unit: interval unit, default is day, can be set to d/day, m/month, y/year
+         * A constant value is prior to the random and increment functions, drop the functions when
+         * more than one of them is configured on the same column.
          *
-         * @param eachColumnConfig see {@link Configuration}
+         * @param column the configuration of the column
          */
-        private void parseMixUpFunctions(Configuration eachColumnConfig)
+        private void removeConflictedItems(Configuration column)
         {
-            String columnValue = eachColumnConfig.getString(Key.VALUE);
-            String columnRandom = eachColumnConfig.getString(StreamConstant.RANDOM);
-            String columnIncr = eachColumnConfig.getString(StreamConstant.INCR);
-            if (StringUtils.isAllBlank(columnRandom, columnIncr)) {
-                eachColumnConfig.getNecessaryValue(Key.VALUE, REQUIRED_VALUE);
+            String columnValue = column.getString(Key.VALUE);
+            String columnRandom = column.getString(StreamConstant.RANDOM);
+            String columnIncr = column.getString(StreamConstant.INCR);
+            if (StringUtils.isBlank(columnValue) || StringUtils.isAllBlank(columnRandom, columnIncr)) {
+                return;
+            }
+
+            LOG.warn("The column value [{}] is a constant, the configured random [{}] / incr [{}] function is ignored.",
+                    columnValue, columnRandom, columnIncr);
+            if (StringUtils.isNotBlank(columnRandom)) {
+                column.remove(StreamConstant.RANDOM);
             }
             if (StringUtils.isNotBlank(columnIncr)) {
-                handleIncrFunction(columnIncr, columnValue, eachColumnConfig);
+                column.remove(StreamConstant.INCR);
             }
-
-            if (StringUtils.isNoneBlank(columnRandom, columnIncr, columnValue)) {
-                LOG.warn("You both configure the constant column(value:{}) and random column(random:{}) " +
-                                "or incr column(incr:{}), constant column is prior to others.",
-                        columnValue, columnRandom, columnIncr);
-                if (StringUtils.isNotBlank(columnRandom)) {
-                    eachColumnConfig.remove(StreamConstant.RANDOM);
-                }
-                if (StringUtils.isNotBlank(columnIncr)) {
-                    eachColumnConfig.remove(StreamConstant.INCR);
-                }
-            }
-            if (StringUtils.isNotBlank(columnRandom)) {
-                handleRandomFunction(columnRandom, eachColumnConfig);
-            }
-        }
-
-        private void handleIncrFunction(String column, String columnValue, Configuration eachColumnConfig)
-        {
-            // 类型判断
-            String dType = eachColumnConfig.getString(Key.TYPE).toLowerCase();
-            if ("long".equals(dType)) {
-                //  columnValue is valid number ?
-                if (!column.contains(",")) {
-                    // setup the default step value
-                    column = column + ",1";
-                    eachColumnConfig.set(StreamConstant.INCR, column);
-                }
-                // validate value
-                try {
-                    Long.parseLong(column.split(",")[0].trim());
-                    Long.parseLong(column.split(",")[1].trim());
-                }
-                catch (NumberFormatException e) {
-                    throw AddaxException.asAddaxException(
-                            ILLEGAL_VALUE,
-                            "The value of  must be numeric, value [" + columnValue + "] is not valid."
-                    );
-                }
-            }
-            else if ("date".equals(dType)) {
-                String[] fields = column.split(",");
-                if (fields.length == 1) {
-                    eachColumnConfig.set(StreamConstant.INCR, column.trim() + ",1,d");
-                }
-                else if (fields.length == 2) {
-                    try {
-                        Integer.parseInt(fields[1]);
-                    }
-                    catch (NumberFormatException e) {
-                        throw AddaxException.asAddaxException(
-                                ILLEGAL_VALUE,
-                                "The second field must be numeric, value [" + fields[1] + "] is not valid"
-                        );
-                    }
-                    eachColumnConfig.set(StreamConstant.INCR, fields[0].trim() + "," + fields[1].trim() + ",d");
-                }
-                else {
-                    String unit = fields[2].charAt(0) + "";
-                    // validate unit
-                    validateDateIncrUnit(unit);
-                    // normalize unit to 1-char
-                    eachColumnConfig.set(StreamConstant.INCR, fields[0].trim() + "," + fields[1].trim() + "," + unit);
-                }
-            }
-            else {
-                throw AddaxException.asAddaxException(
-                        NOT_SUPPORT_TYPE,
-                        "The increment sequence must be long or date, value [" + dType + "] is not valid."
-                );
-            }
-            this.originalConfig.set(StreamConstant.HAVE_INCR_FUNCTION, true);
-        }
-
-        private void handleRandomFunction(String columnRandom, Configuration eachColumnConfig)
-        {
-            String[] split = columnRandom.split(",");
-            if (split.length < 2) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        String.format("Illegal random value [%s], supported random value like 'minVal, MaxVal[,scale]'",
-                                columnRandom));
-            }
-            String param1 = split[0];
-            long param1Int;
-            String param2 = split[1];
-            long param2Int;
-            if (StringUtils.isBlank(param1) && StringUtils.isBlank(param2)) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        "The random function's params can not be empty.");
-            }
-
-            String typeName = eachColumnConfig.getString(Key.TYPE);
-            if (Type.DATE.name().equalsIgnoreCase(typeName)) {
-                String dateFormat = eachColumnConfig.getString(Key.DATE_FORMAT, StreamConstant.DEFAULT_DATE_FORMAT);
-                try {
-                    SimpleDateFormat format = new SimpleDateFormat(
-                            eachColumnConfig.getString(Key.DATE_FORMAT, StreamConstant.DEFAULT_DATE_FORMAT));
-                    //warn: do no concern int -> long
-                    param1Int = format.parse(param1).getTime();//milliseconds
-                    param2Int = format.parse(param2).getTime();//milliseconds
-                }
-                catch (ParseException e) {
-                    throw AddaxException.asAddaxException(
-                            ILLEGAL_VALUE,
-                            String.format("The random function's params [%s,%s] does not match the dateFormat[%s].",
-                                    dateFormat, param1, param2), e);
-                }
-            }
-            else {
-                param1Int = Integer.parseInt(param1);
-                param2Int = Integer.parseInt(param2);
-            }
-            if (param1Int < 0 || param2Int < 0) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        String.format("The random function's params [%s,%s] can not be negative.",
-                                param1, param2));
-            }
-            if (!Type.BOOL.name().equalsIgnoreCase(typeName) && param1Int > param2Int) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        String.format("The random function's params [%s,%s] is not valid, the first param must be less than the second one.",
-                                param1, param2));
-            }
-            eachColumnConfig.set(StreamConstant.MIXUP_FUNCTION_PARAM1, param1Int);
-            eachColumnConfig.set(StreamConstant.MIXUP_FUNCTION_PARAM2, param2Int);
-            if (split.length == 3) {
-                int scale = Integer.parseInt(split[2].trim());
-                eachColumnConfig.set(StreamConstant.MIXUP_FUNCTION_SCALE, scale);
-            }
-            this.originalConfig.set(StreamConstant.HAVE_MIXUP_FUNCTION, true);
-        }
-
-        /**
-         * valid the unit
-         * current support unit are the following:
-         * 1. d/day
-         * 2. M/month
-         * 3. y/year
-         * 4. h/hour
-         * 5. m/minute
-         * 6. s/second
-         * 7. w/week
-         *
-         * @param unit the date interval unit
-         */
-        private void validateDateIncrUnit(String unit)
-        {
-            boolean isOK = true;
-            if (unit.length() == 1) {
-                if (!validUnits.contains(unit)) {
-                    isOK = false;
-                }
-            }
-            else if (!validUnits.contains(unit.toLowerCase())) {
-                isOK = false;
-            }
-            if (!isOK) {
-                throw AddaxException.asAddaxException(
-                        ILLEGAL_VALUE,
-                        unit + " is NOT valid interval unit，for more details, please refer to the documentation");
-            }
-        }
-
-        @Override
-        public void prepare()
-        {
-            //
         }
 
         @Override
         public List<Configuration> split(int adviceNumber)
         {
-            List<Configuration> configurations = new ArrayList<>();
-
+            List<Configuration> configurations = new ArrayList<>(adviceNumber);
             for (int i = 0; i < adviceNumber; i++) {
-                configurations.add(this.originalConfig.clone());
+                Configuration configuration = this.originalConfig.clone();
+                // The increment functions have to produce a unique sequence over all the slices.
+                // Instead of sharing a counter between the concurrently running tasks, every slice
+                // takes a disjoint part of the sequence: the record whose ordinal inside the whole
+                // job is `n` belongs to the slice `n % adviceNumber` and is its `n / adviceNumber`
+                // record. So a slice starts at `i` and steps by `adviceNumber`.
+                configuration.set(StreamConstant.SLICE_INDEX, i);
+                configuration.set(StreamConstant.SLICE_COUNT, adviceNumber);
+                configurations.add(configuration);
             }
             return configurations;
-        }
-
-        @Override
-        public void post()
-        {
-            //
         }
 
         @Override
@@ -385,50 +143,51 @@ public class StreamReader
     public static class Task
             extends Reader.Task
     {
-        private List<String> columns;
+        private List<ColumnSpec> columns;
 
         private long sliceRecordCount;
 
-        private boolean haveMixUpFunction;
-        private boolean haveIncrFunction;
+        /** The ordinal of the first record of this slice inside the whole job. */
+        private int sliceIndex;
 
-        // 递增字段字段，用于存储当前的递增值
-        private static final Map<Integer, Object> incrMap = new ConcurrentHashMap<>(8);
+        /** The total number of slices of the job. */
+        private int sliceCount;
+
+        /** True when every column of the record is a constant, the record is built only once. */
+        private boolean fixedValue;
+
+        private final RandomGenerator rng = RandomGenerator.of("Xoroshiro128PlusPlus");
 
         @Override
         public void init()
         {
             Configuration readerSliceConfig = getPluginJobConf();
-            this.columns = readerSliceConfig.getList(Key.COLUMN, String.class);
+            this.columns = readerSliceConfig.getList(Key.COLUMN, String.class).stream()
+                    .map(column -> ColumnSpec.parse(Configuration.from(column)))
+                    .toList();
 
             this.sliceRecordCount = readerSliceConfig.getLong(Key.SLICE_RECORD_COUNT);
-            this.haveMixUpFunction = readerSliceConfig.getBool(StreamConstant.HAVE_MIXUP_FUNCTION, false);
-            this.haveIncrFunction = readerSliceConfig.getBool(StreamConstant.HAVE_INCR_FUNCTION, false);
-        }
-
-        @Override
-        public void prepare()
-        {
-            //
+            this.sliceIndex = readerSliceConfig.getInt(StreamConstant.SLICE_INDEX, 0);
+            this.sliceCount = readerSliceConfig.getInt(StreamConstant.SLICE_COUNT, 1);
+            this.fixedValue = this.columns.stream().allMatch(column -> column.rule() instanceof ColumnSpec.ConstantValue);
         }
 
         @Override
         public void startRead(RecordSender recordSender)
         {
-            Record oneRecord = buildOneRecord(recordSender, this.columns);
-            while (this.sliceRecordCount > 0) {
-                recordSender.sendToWriter(oneRecord);
-                this.sliceRecordCount--;
-                if (this.haveMixUpFunction || this.haveIncrFunction) {
-                    oneRecord = buildOneRecord(recordSender, this.columns);
+            if (this.fixedValue) {
+                Record record = buildOneRecord(recordSender, 0L);
+                for (long i = 0; i < this.sliceRecordCount; i++) {
+                    recordSender.sendToWriter(record);
                 }
+                return;
             }
-        }
 
-        @Override
-        public void post()
-        {
-            //
+            long ordinal = this.sliceIndex;
+            for (long i = 0; i < this.sliceRecordCount; i++) {
+                recordSender.sendToWriter(buildOneRecord(recordSender, ordinal));
+                ordinal += this.sliceCount;
+            }
         }
 
         @Override
@@ -437,171 +196,23 @@ public class StreamReader
             //
         }
 
-        private Column buildOneColumn(Configuration eachColumnConfig, int columnIndex)
-                throws Exception
-        {
-            String columnValue = eachColumnConfig.getString(Key.VALUE);
-            if ("null".equals(columnValue)) {
-                return new StringColumn();
-            }
-            Type columnType = Type.valueOf(eachColumnConfig.getString(Key.TYPE).toUpperCase());
-            String columnRandom = eachColumnConfig.getString(StreamConstant.RANDOM);
-            String columnIncr = eachColumnConfig.getString(StreamConstant.INCR);
-            long param1Int = eachColumnConfig.getLong(StreamConstant.MIXUP_FUNCTION_PARAM1, 0L);
-            long param2Int = eachColumnConfig.getLong(StreamConstant.MIXUP_FUNCTION_PARAM2, 1L);
-            int scale = eachColumnConfig.getInt(StreamConstant.MIXUP_FUNCTION_SCALE, -1);
-            boolean isColumnMixup = StringUtils.isNotBlank(columnRandom);
-            boolean isIncr = StringUtils.isNotBlank(columnIncr);
-            UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
-            if (isColumnMixup) {
-                return handleMixupColumn(columnType, rng, param1Int, param2Int, scale);
-            }
-            if (isIncr) {
-                return handleIncrColumn(eachColumnConfig, columnIndex, columnType, columnIncr);
-            }
-
-            // in fact,never to be here
-            return switch (columnType) {
-                case STRING -> new StringColumn(columnValue);
-                case LONG -> new LongColumn(columnValue);
-                case DOUBLE -> new DoubleColumn(columnValue);
-                case DATE -> {
-                    SimpleDateFormat format = new SimpleDateFormat(eachColumnConfig.getString(Key.DATE_FORMAT, StreamConstant.DEFAULT_DATE_FORMAT));
-                    yield new DateColumn(format.parse(columnValue));
-                }
-                case BOOL -> new BoolColumn("true".equalsIgnoreCase(columnValue));
-                case BYTES -> new BytesColumn(columnValue.getBytes());
-                case TIMESTAMP -> new TimestampColumn(columnValue);
-                default -> throw new Exception(String.format("The column type [%s] is unsupported.", columnType.name()));
-            };
-        }
-
-        private Column handleIncrColumn(Configuration eachColumnConfig, int columnIndex, Type columnType, String columnIncr)
-        {
-            Object currVal;
-            long step;
-            if (columnType == Type.LONG) {
-                //get initial value and step
-                currVal = Long.parseLong(columnIncr.split(",")[0]);
-                step = Long.parseLong(columnIncr.split(",")[1]);
-                currVal = incrMap.getOrDefault(columnIndex, currVal);
-                incrMap.put(columnIndex, (long) currVal + step);
-                return new LongColumn((long) currVal);
-            }
-            else if (columnType == Type.DATE) {
-                String[] fields = columnIncr.split(",");
-                currVal = incrMap.getOrDefault(columnIndex, null);
-                if (currVal == null) {
-                    String datePattern = eachColumnConfig.getString(Key.DATE_FORMAT, StreamConstant.DEFAULT_DATE_FORMAT);
-                    SimpleDateFormat sdf = new SimpleDateFormat(datePattern);
-                    try {
-                        currVal = sdf.parse(fields[0]);
-                    }
-                    catch (ParseException e) {
-                        throw AddaxException.asAddaxException(
-                                ILLEGAL_VALUE,
-                                String.format("can not parse date value [%s] with date format [%s]", fields[0], datePattern)
-                        );
-                    }
-                }
-                incrMap.put(columnIndex, dateIncrement((Date) currVal, Integer.parseInt(fields[1]), fields[2]));
-                return new DateColumn((Date) currVal);
-            }
-            else {
-                throw AddaxException.asAddaxException(
-                        NOT_SUPPORT_TYPE,
-                        columnType + " can not support for increment"
-                );
-            }
-        }
-
-        private Column handleMixupColumn(Type columnType, UniformRandomProvider rng, long param1Int, long param2Int, int scale)
-                throws Exception
-        {
-            switch (columnType) {
-                case STRING:
-                    return new StringColumn(RandomStringUtils.insecure().nextAlphanumeric(
-                            (int) rng.nextLong(param1Int, param2Int + 1)));
-                case LONG:
-                    return new LongColumn(rng.nextLong(param1Int, param2Int + 1));
-                case DOUBLE:
-                    // specify fixed scale or not ?
-                    if (scale > 0) {
-                        BigDecimal b = BigDecimal.valueOf(rng.nextDouble(param1Int, param2Int + 1))
-                                .setScale(scale, RoundingMode.HALF_UP);
-                        return new DoubleColumn(b.doubleValue());
-                    }
-                    else {
-                        return new DoubleColumn(rng.nextDouble(param1Int, param2Int + 1));
-                    }
-                case DATE:
-                    return new DateColumn(new Date(rng.nextLong(param1Int, param2Int + 1)));
-                case BOOL:
-                    // warn: no concern -10 etc..., how about (0, 0)(0, 1)(1,2)
-                    if (param1Int == param2Int) {
-                        param1Int = 0;
-                        param2Int = 1;
-                    }
-                    if (param1Int == 0) {
-                        return new BoolColumn(true);
-                    }
-                    else if (param2Int == 0) {
-                        return new BoolColumn(false);
-                    }
-                    else {
-                        long randomInt = rng.nextLong(0, param1Int + param2Int + 1);
-                        return new BoolColumn(randomInt > param1Int);
-                    }
-                case BYTES:
-                    return new BytesColumn(RandomStringUtils.insecure().nextAlphanumeric((int)
-                            rng.nextLong(param1Int, param2Int + 1)).getBytes());
-                case TIMESTAMP:
-                    return new TimestampColumn(rng.nextLong(1_100_000_000_000L, 2_100_000_000_000L));
-                default:
-                    // in fact,never to be here
-                    throw new Exception("The type " + columnType.name() + "is not supported");
-            }
-        }
-
         /**
-         * calculate next date via interval
+         * Build the record whose ordinal inside the whole job is {@code ordinal}.
          *
-         * @param curDate current date
-         * @param step interval
-         * @param unit unit
-         * @return next date
+         * @param recordSender the sender of the record
+         * @param ordinal the ordinal of the record inside the whole job
+         * @return the record
          */
-        private Date dateIncrement(Date curDate, int step, String unit)
+        private Record buildOneRecord(RecordSender recordSender, long ordinal)
         {
-            return switch (unit) {
-                case "d" -> DateUtils.addDays(curDate, step);
-                case "M" -> DateUtils.addMonths(curDate, step);
-                case "y" -> DateUtils.addYears(curDate, step);
-                case "w" -> DateUtils.addWeeks(curDate, step);
-                case "h" -> DateUtils.addHours(curDate, step);
-                case "m" -> DateUtils.addMinutes(curDate, step);
-                case "s" -> DateUtils.addSeconds(curDate, step);
-                default -> DateUtils.addDays(curDate, step);
-            };
-        }
-
-        private Record buildOneRecord(RecordSender recordSender,
-                List<String> columns)
-        {
-            if (null == recordSender) {
-                throw new IllegalArgumentException("The parameter recordSender must not be null.");
-            }
-
-            if (null == columns || columns.isEmpty()) {
-                throw new IllegalArgumentException("The parameter columns must not be null or empty.");
-            }
-
             Record record = recordSender.createRecord();
             try {
-                for (int i = 0; i < columns.size(); i++) {
-                    Configuration eachColumnConfig = Configuration.from(columns.get(i));
-                    record.addColumn(this.buildOneColumn(eachColumnConfig, i));
+                for (ColumnSpec column : this.columns) {
+                    record.addColumn(column.toColumn(ordinal, this.rng));
                 }
+            }
+            catch (AddaxException e) {
+                throw e;
             }
             catch (Exception e) {
                 throw AddaxException.asAddaxException(ILLEGAL_VALUE,


### PR DESCRIPTION
## Summary
<!-- Provide a short description of what this PR changes and why. -->
Fixes the logic defects of the `streamreader` plugin and modernizes it for JDK 17. The most
serious defect was the shared increment counter, which made the generated sequence repeat
values under concurrency and leak state between jobs. The column model is reworked so that a
column is parsed and validated once, and no configuration is read on the hot path.

## Related Issue(s)
<!-- Link to any existing issues this PR addresses: Fixes #123, Relates to #456 -->
None.

## What type of change is this?
<!-- Check one or more boxes: -->
- [x] Bugfix
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI
- [x] Chore / Refactor
- [x] Breaking change (changes API or runtime behavior)

## Changes
<!-- Describe the main changes in this PR. Keep each change short and focused. -->

**Bug fixes**

1. `incrMap` was `static`, so all concurrently running tasks of a job — and all jobs of the
   same JVM, since the server module runs them on a shared class loader — competed for the
   same counters. `getOrDefault` + `put` is not atomic, so the increment columns produced
   duplicate values and leaked state into the following job. The map is gone: `Job.split()`
   stamps `sliceIndex`/`sliceCount` into each slice and the value becomes
   `start + ordinal * step`, so the slices own disjoint parts of one sequence.
2. The documented "the constant value is prior to the other functions" rule only applied when
   `value`, `random` and `incr` were all set (`isNoneBlank` over three arguments), so a
   `value` + `random` column silently produced random data.
3. `random 5,5` on a bool column always returned `true`: equal bounds were rewritten to
   `0,1` and then hit the "never yields false" branch.
4. `bytes` used the platform default charset although the documentation promises UTF-8.
5. The random params were read with `Integer.parseInt` although they are stored as `long`,
   so a large bound threw a raw `NumberFormatException` while validating the job.
6. The date `incr` item was only partially validated: an empty unit, more than three fields,
   or a non numeric step either crashed with `StringIndexOutOfBoundsException` or failed
   later inside a task with a raw `NumberFormatException`.
7. `catch (Exception)` re-wrapped an inner `AddaxException` into `ILLEGAL_VALUE`, losing the
   original error code.

**JDK 17 / structure**

- `commons-rng-simple` is replaced by `java.util.random.RandomGenerator` (JEP 356): the JDK
  provides the same `Xoroshiro128PlusPlus` algorithm with identical interval semantics, so the
  plugin no longer ships its three jars (194KB).
- A column is now parsed and validated once into an immutable `ColumnSpec`
  (`record` + `sealed interface Rule`), with pattern matching in `instanceof`. This removes
  the per-record `Configuration.from()` JSON parse, the per-record `SimpleDateFormat`, the
  per-record `String.split(",")` and the PRNG constructed for every column of every record.
- The `hasMixupFunction` / `hasIncrFunction` and `mixupParam*` items that were injected into
  the user configuration are gone; the task derives this from the parsed rules.
- Date handling uses `java.time` (`DateTimeFormatter`, `ChronoUnit`), and the unit string maps
  directly onto a `ChronoUnit` instead of a runtime `switch`.

Net effect on the module: `StreamReader.java` shrinks from 613 to 224 lines, the parsing and
validation live in the new `ColumnSpec.java`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The plugin is meant to generate predictable test data, but the increment columns — its most
common use — could not be trusted with more than one channel: the sequence contained
duplicates and depended on what other jobs had run in the same JVM before. The remaining
defects were found while reviewing the class.

## How has this been tested?
The module builds with `mvn clean package -pl :streamreader -am -DskipTests` and
`spotbugs:check` reports no findings on the new code.

Manual end-to-end runs with `streamreader` -> `streamwriter` against a real install:

1. Constant columns from the plugin template, including the `"null"` literal (SQL NULL) and
   a custom `dateFormat` for a `date` column - all values as expected.
2. `channel: 3` with `sliceRecordCount: 4` on a job combining `incr` (long and date) with
   `random` (long, double with scale, bool, string, bytes, date, timestamp). The increment
   column yields exactly `1..12`, each value once, and the date column matches the ordinal.
   The raw output shows the three reader threads interleaving, which is the case that used to
   duplicate values.
3. The layout that motivated the fix, `{"incr": "1, 100", "type": "long"}` with `channel: 3`
   and `sliceRecordCount: 10`, produces 30 unique values `1, 101, ... 2901`.
4. A `value` + `random` column now keeps the constant and logs a warning; `random 5,5` on a
   bool column yields an even split (97/103 over 200 records).
5. 15 invalid configurations (unknown type, non numeric incr, empty unit, reversed random
   bounds, bad scale, unparseable date, ...) all fail at job startup with a readable message.

No unit tests were added, per the project convention that the tests are executed manually.

## Checklist (required)
- [x] I have read the project's contributing guidelines and code of conduct.
- [x] My change includes appropriate tests (if applicable).
- [x] I ran a local build and fixed any compilation issues.
- [x] I updated or added documentation if needed (README, docs/ or docs/en/).
- [ ] I updated CHANGELOG.md when appropriate.
- [x] I have not added any secrets or credentials.
- [x] I have checked for sensitive or personal data in this PR.
- [ ] I added the `Signed-off-by` line in the final commit message if required by the project.

## Checklist for maintainers / reviewers (recommended)
- [ ] Verify the implementation follows project conventions and style.
- [ ] Confirm tests (unit/integration) and CI pass.
- [ ] Check release notes / CHANGELOG entry.
- [x] Evaluate whether the change requires a migration note.

## Release notes
`streamreader`: the increment columns now produce a unique sequence across all channels
(`start + record ordinal * step`), the `value` item takes precedence over `random`/`incr` with
a warning, and the module no longer depends on `commons-rng-simple`.

## Breaking changes / Migration
Behaviour changes for existing jobs:

- A column that configures both `value` and `random`/`incr` now uses the constant value. Such
  a column previously produced random data and now logs a warning; remove the redundant item
  to silence it. This matches the behaviour the documentation already described.
- Date increments with the `M` (month) and `y` (year) units are computed from the configured
  start date instead of being accumulated record by record, so they no longer drift at month
  ends: `1989-01-31` with `incr 1,M` now yields `01-31, 02-28, 03-31, 04-30`.
- Dates are parsed with `DateTimeFormatter` (SMART) instead of the lenient
  `SimpleDateFormat`, so an invalid date such as `2020-13-45 00:00:00` is now rejected at
  startup instead of being rolled over into the next year.
- Invalid `random`/`incr` items now fail while the job is initialized rather than inside a
  task, so a previously "working" job with a malformed item may now fail fast.

No API change: the job configuration items are the same.

## Security
<!-- If this PR fixes a security vulnerability, DO NOT include exploit details in this public description. -->
Not applicable.

## Additional context
The same defects exist in `plugin/reader/datareader`, which is a copy of this class (its
counter is a non thread safe `HashMap`). It is left untouched here and can be handled in a
follow-up.
